### PR TITLE
Fix toggling margin when closing sidenav-menugroup

### DIFF
--- a/ontimize/components/app-sidenav/o-app-sidenav.component.scss
+++ b/ontimize/components/app-sidenav/o-app-sidenav.component.scss
@@ -182,6 +182,7 @@ $transition-duration: 500ms;
 
         .application-sidenav-menugroup {
           padding: ($sidenav-spacing-unit * 2);
+          transition: padding 0s $transition-duration;
           .application-sidenav-menugroup-arrow {
             position: absolute;
             right: ($sidenav-spacing-unit * 2);
@@ -195,6 +196,7 @@ $transition-duration: 500ms;
             + .application-sidenav-menugroup-items-container {
               ul li > a {
                 padding-left: ($sidenav-spacing-unit * 4);
+                transition: padding 0s;
               }
             }
           }


### PR DESCRIPTION
I added a delay when changing the padding property, so the menu collapses before it changes