### PR TITLE
#154 Splits comparison between types

### DIFF
--- a/ontimize/components/table/column/cell-editor/boolean/o-table-cell-editor-boolean.component.ts
+++ b/ontimize/components/table/column/cell-editor/boolean/o-table-cell-editor-boolean.component.ts
@@ -59,20 +59,36 @@ export class OTableCellEditorBooleanComponent extends OBaseTableCellEditor {
     }
     return cellData;
   }
+  
+  private OTCEBC_parseValueFromString(val: string): boolean {
+    return Util.parseBoolean(val, false);
+  }
+  
+  private OTCEBC_parseValueFromNumber(val: string|number): number {
+    return (parseInt(val) === 1) ? 1 : 0;
+  }
+  
+  private OTCEBC_parseValueFromBoolean(val: any): boolean {
+    return (val === true);
+  }
 
-  protected parseValueByType(val: any): any {
-    let result = val;
+  protected parseValueByType(val: any): boolean|number {
+    let result;
+    // check if booleanType exists or the switch will break
+    if (!this.booleanType) {
+      result = this.OTCEBC_parseValueFromBoolean(val);
+    }
     switch (this.booleanType) {
       case 'string':
-        result = Util.parseBoolean(val, false);
+        result = this.OTCEBC_parseValueFromString(val);
         break;
       case 'number':
-        result = (val === 1);
+        result = this.OTCEBC_parseValueFromNumber(val);
         break;
       case 'boolean':
       default:
         // boolean comparision as default value of dataType
-        result = (val === true);
+        result = this.OTCEBC_parseValueFromBoolean(val);
         break;
     }
     return result;


### PR DESCRIPTION
Makes more visible the input types and returned types for each case,
adds protection against undefined on switch,
adds protection against number typed as string,
solves #154 making the internal value to be a number