### PR TITLE
New `o-table` attribute `visible-export-dialog-buttons`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 4.1.3
 ### Features
-* **o-table**: new attribute `show-filter-option` [#318](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/318)
+* **o-table**:
+  * new attribute `show-filter-option` ([#318](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/318))
+  * new attribute `visible-export-dialog-buttons` ([#320](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/320)). Closes [#316](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/316)
 
 ### Bug Fixes
 * **o-time-input**: Fix bad behaviour when there is more than one component in the same form ([fc1dd47](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fc1dd47))

--- a/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.html
+++ b/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.html
@@ -2,12 +2,12 @@
 <mat-dialog-content>
   <div mat-subheader>{{ 'TABLE.DIALOG.EXPORT.DESCRIPTION' | oTranslate }}</div>
   <div fxLayout="row wrap" fxLayoutAlign="space-around center" fxLayoutGap="8px">
-    <o-table-export-button #excelButton svg-icon="ontimize:EXCEL" label="TABLE.BUTTONS.EXCEL" export-type="xlsx"
+    <o-table-export-button #excelButton *ngIf="isButtonVisible('excel')" svg-icon="ontimize:EXCEL" label="TABLE.BUTTONS.EXCEL" export-type="xlsx"
       (onClick)="export('xlsx', excelButton)" class="excel-button"></o-table-export-button>
-    <o-table-export-button #htmlButton svg-icon="ontimize:HTML" label="TABLE.BUTTONS.HTML" export-type="html" (onClick)="export('html', htmlButton)"
-      class="html-button"></o-table-export-button>
-    <o-table-export-button #pdfButton svg-icon="ontimize:PDF" label="TABLE.BUTTONS.PDF" export-type="pdf" (onClick)="export('pdf', pdfButton)"
-      class="pdf-button"></o-table-export-button>
+    <o-table-export-button #htmlButton *ngIf="isButtonVisible('html')" svg-icon="ontimize:HTML" label="TABLE.BUTTONS.HTML" export-type="html"
+      (onClick)="export('html', htmlButton)" class="html-button"></o-table-export-button>
+    <o-table-export-button #pdfButton *ngIf="isButtonVisible('pdf')" svg-icon="ontimize:PDF" label="TABLE.BUTTONS.PDF" export-type="pdf"
+      (onClick)="export('pdf', pdfButton)" class="pdf-button"></o-table-export-button>
     <ng-container *ngTemplateOutlet="config.options"></ng-container>
   </div>
 </mat-dialog-content>

--- a/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
+++ b/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
@@ -1,8 +1,9 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, Inject, Injector, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
-import { MatButton, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material';
+import { MAT_DIALOG_DATA, MatButton, MatDialogRef } from '@angular/material';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
+
 import { DialogService, OntimizeExportService, OTranslateService } from '../../../../../services';
 import { Codes, SQLTypes, Util } from '../../../../../utils';
 import { OTableExportButtonService } from '../../export-button/o-table-export-button.service';
@@ -17,6 +18,7 @@ export class OTableExportConfiguration {
   filter?: Object;
   mode: string;
   entity: string;
+  visibleButtons: string;
   options?: any;
 }
 
@@ -38,6 +40,7 @@ export class OTableExportDialogComponent implements OnInit, OnDestroy {
   protected exportService: OntimizeExportService;
   protected translateService: OTranslateService;
   protected oTableExportButtonService: OTableExportButtonService;
+  protected visibleButtons: string[];
   private subscription: Subscription = new Subscription();
 
   constructor(
@@ -48,6 +51,10 @@ export class OTableExportDialogComponent implements OnInit, OnDestroy {
     this.dialogService = injector.get(DialogService);
     this.translateService = this.injector.get(OTranslateService);
     this.oTableExportButtonService = this.injector.get(OTableExportButtonService);
+
+    if (config && Util.isDefined(config.visibleButtons)) {
+      this.visibleButtons = Util.parseArray(config.visibleButtons.toLowerCase(), true);
+    }
   }
 
   ngOnInit() {
@@ -123,6 +130,10 @@ export class OTableExportDialogComponent implements OnInit, OnDestroy {
         });
       }
     });
+  }
+
+  isButtonVisible(btn: string): boolean {
+    return !this.visibleButtons || (this.visibleButtons.indexOf(btn) !== -1);
   }
 
   protected handleError(err): void {

--- a/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
+++ b/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
@@ -317,6 +317,7 @@ export class OTableMenuComponent implements OnInit, AfterViewInit, OnDestroy {
     exportCnfg.sqlTypes = this.table.getSqlTypes();
     // Table service, needed for configuring ontimize export service with table service configuration
     exportCnfg.service = this.table.service;
+    exportCnfg.visibleButtons = this.table.visibleExportDialogButtons;
     exportCnfg.options = this.table.exportOptsTemplate;
 
     let dialogRef = this.dialog.open(OTableExportDialogComponent, {

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -160,7 +160,7 @@ export const DEFAULT_INPUTS_O_TABLE = [
   // show-filter-option [yes|no|true|false]: show filter menu option in the header menu. Default: yes.
   'showFilterOption: show-filter-option',
 
-  // visible-export-dialog-buttons [string]: visible buttons in export dialog, separated by ';'. Default: 'pdf;excel;html'.
+  // visible-export-dialog-buttons [string]: visible buttons in export dialog, separated by ';'. Default/no configured: show all. Empty value: hide all.
   'visibleExportDialogButtons: visible-export-dialog-buttons'
 ];
 

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -158,7 +158,10 @@ export const DEFAULT_INPUTS_O_TABLE = [
   'exportMode: export-mode',
 
   // show-filter-option [yes|no|true|false]: show filter menu option in the header menu. Default: yes.
-  'showFilterOption: show-filter-option'
+  'showFilterOption: show-filter-option',
+
+  // visible-export-dialog-buttons [string]: visible buttons in export dialog, separated by ';'. Default: 'pdf;excel;html'.
+  'visibleExportDialogButtons: visible-export-dialog-buttons'
 ];
 
 export const DEFAULT_OUTPUTS_O_TABLE = [
@@ -598,6 +601,7 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
   keepSelectedItems: boolean = true;
 
   public exportMode: string = Codes.EXPORT_MODE_VISIBLE;
+  public visibleExportDialogButtons: string;
   public daoTable: OTableDao | null;
   public dataSource: OTableDataSource | null;
   public visibleColumns: string;


### PR DESCRIPTION
Visible buttons in export dialog, separated by ';'.
Default/not configured: show all.
Empty value (`visible-export-dialog-buttons=""`): hide all.

Closes #316