### PR TITLE
Feature/4.x.x allow extend export service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * **o-table**:
   * new attribute `show-filter-option` ([#318](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/318))
   * new attribute `visible-export-dialog-buttons` ([#320](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/320)). Closes [#316](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/316)
+  * new attribute `export-service-type` ([0f2db1c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0f2db1c))
+* **App configuration**: new attribute `exportServiceType` allows configuring the service used for exportation in the whole application ([c785371](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c785371))
 
 ### Bug Fixes
 * **o-time-input**: Fix bad behaviour when there is more than one component in the same form ([fc1dd47](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fc1dd47))

--- a/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
+++ b/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 import { DialogService, OntimizeExportService, OTranslateService } from '../../../../../services';
+import { exportServiceFactory } from '../../../../../services/export-service.provider';
 import { IExportService } from '../../../../../types/export-service.interface';
 import { Codes, SQLTypes, Util } from '../../../../../utils';
 import { OTableExportButtonService } from '../../export-button/o-table-export-button.service';
@@ -28,7 +29,9 @@ export class OTableExportConfiguration {
   selector: 'o-table-export-dialog',
   templateUrl: 'o-table-export-dialog.component.html',
   styleUrls: ['o-table-export-dialog.component.scss'],
-  providers: [OntimizeExportService],
+  providers: [
+    { provide: OntimizeExportService, useFactory: exportServiceFactory, deps: [Injector] }
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     'class': 'o-table-export-dialog'

--- a/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
+++ b/ontimize/components/table/extensions/dialog/export/o-table-export-dialog.component.ts
@@ -5,15 +5,16 @@ import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 import { DialogService, OntimizeExportService, OTranslateService } from '../../../../../services';
+import { IExportService } from '../../../../../types/export-service.interface';
 import { Codes, SQLTypes, Util } from '../../../../../utils';
 import { OTableExportButtonService } from '../../export-button/o-table-export-button.service';
-
 
 export class OTableExportConfiguration {
   columns: Array<any>;
   columnNames: Object;
   sqlTypes: Object;
   service: string;
+  serviceType: string;
   data?: any[];
   filter?: Object;
   mode: string;
@@ -37,7 +38,7 @@ export class OTableExportConfiguration {
 export class OTableExportDialogComponent implements OnInit, OnDestroy {
 
   protected dialogService: DialogService;
-  protected exportService: OntimizeExportService;
+  protected exportService: IExportService;
   protected translateService: OTranslateService;
   protected oTableExportButtonService: OTableExportButtonService;
   protected visibleButtons: string[];
@@ -74,17 +75,12 @@ export class OTableExportDialogComponent implements OnInit, OnDestroy {
 
   configureService(): void {
     let loadingService: any = OntimizeExportService;
-    // TODO: allow service type selection (extension)
-    // if (this.serviceType) {
-    //   loadingService = this.serviceType;
-    // }
-    try {
-      this.exportService = this.injector.get(loadingService);
-      let serviceCfg = this.exportService.getDefaultServiceConfiguration(this.config.service);
-      this.exportService.configureService(serviceCfg, Codes.EXPORT_MODE_ALL === this.config.mode);
-    } catch (e) {
-      console.error(e);
+    if (this.config.serviceType) {
+      loadingService = this.config.serviceType;
     }
+    this.exportService = this.injector.get(loadingService);
+    let serviceCfg = this.exportService.getDefaultServiceConfiguration(this.config.service);
+    this.exportService.configureService(serviceCfg, Codes.EXPORT_MODE_ALL === this.config.mode);
   }
 
   export(exportType: string, button?: MatButton): void {
@@ -100,21 +96,11 @@ export class OTableExportDialogComponent implements OnInit, OnDestroy {
     };
     let self = this;
     this.proccessExportData(exportData.data, exportData.sqlTypes);
-    this.exportService.exportData(exportData, exportType, this.config.entity).subscribe((resp) => {
-      if (resp.code === Codes.ONTIMIZE_SUCCESSFUL_CODE) {
-        self.exportService.downloadFile(resp.data[0][exportType + 'Id'], exportType).subscribe(
-          () => self.dialogRef.close(true),
-          downloadError => {
-            console.error(downloadError);
-            self.dialogService.alert('ERROR', downloadError.message).then(() => self.dialogRef.close(false));
-          }
-        );
-      } else {
-        self.dialogService.alert('ERROR', resp.message).then(() => self.dialogRef.close(false));
-      }
-    },
-      (err) => self.handleError(err)
-    );
+    this.exportService.exportData(exportData, exportType, this.config.entity)
+      .subscribe(
+        res => self.dialogRef.close(true),
+        err => self.handleError(err)
+      );
   }
 
   proccessExportData(data: Object[], sqlTypes: Object): void {

--- a/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
+++ b/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
@@ -318,6 +318,7 @@ export class OTableMenuComponent implements OnInit, AfterViewInit, OnDestroy {
     // Table service, needed for configuring ontimize export service with table service configuration
     exportCnfg.service = this.table.service;
     exportCnfg.visibleButtons = this.table.visibleExportDialogButtons;
+    exportCnfg.serviceType = this.table.exportServiceType;
     exportCnfg.options = this.table.exportOptsTemplate;
 
     let dialogRef = this.dialog.open(OTableExportDialogComponent, {

--- a/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
+++ b/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
@@ -317,8 +317,8 @@ export class OTableMenuComponent implements OnInit, AfterViewInit, OnDestroy {
     exportCnfg.sqlTypes = this.table.getSqlTypes();
     // Table service, needed for configuring ontimize export service with table service configuration
     exportCnfg.service = this.table.service;
-    exportCnfg.visibleButtons = this.table.visibleExportDialogButtons;
     exportCnfg.serviceType = this.table.exportServiceType;
+    exportCnfg.visibleButtons = this.table.visibleExportDialogButtons;
     exportCnfg.options = this.table.exportOptsTemplate;
 
     let dialogRef = this.dialog.open(OTableExportDialogComponent, {

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -157,6 +157,9 @@ export const DEFAULT_INPUTS_O_TABLE = [
   // export-mode ['visible'|'local'|'all']: sets the mode to export data. Default: 'visible'
   'exportMode: export-mode',
 
+  // exportServiceType [ string ]: The service used by the table for exporting it's data, it must implement 'IExportService' interface. Default: 'OntimizeExportService'
+  'exportServiceType: export-service-type',
+
   // show-filter-option [yes|no|true|false]: show filter menu option in the header menu. Default: yes.
   'showFilterOption: show-filter-option',
 
@@ -601,6 +604,7 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
   keepSelectedItems: boolean = true;
 
   public exportMode: string = Codes.EXPORT_MODE_VISIBLE;
+  public exportServiceType: string;
   public visibleExportDialogButtons: string;
   public daoTable: OTableDao | null;
   public dataSource: OTableDataSource | null;

--- a/ontimize/config/app-config.ts
+++ b/ontimize/config/app-config.ts
@@ -72,6 +72,9 @@ export interface Config {
   // serviceType [ undefined | '' | class ]: The service type used (Ontimize REST standart, Ontimize REST JEE or custom implementation) in the whole application. By default 'undefined', that is, Ontimize REST standard service.
   serviceType?: any;
 
+  // exportServiceType [ undefined | '' | class ]: The service used for exportation in the whole application. It shold implement `IExportService` interface. By default 'undefined' OntimizeExportService.
+  exportServiceType?: any;
+
   // servicesConfiguration: [Object]: Configuration parameters of application services.
   servicesConfiguration?: Object;
 

--- a/ontimize/config/o-providers.ts
+++ b/ontimize/config/o-providers.ts
@@ -4,9 +4,30 @@ import { BaseRequestOptions, XHRBackend } from '@angular/http';
 import { MAT_RIPPLE_GLOBAL_OPTIONS } from '@angular/material';
 import { Router } from '@angular/router';
 import { combineLatest } from 'rxjs';
+
 import { OContextMenuService } from '../components/contextmenu/o-context-menu.service';
 import { AppConfig, Config } from '../config/app-config';
-import { appConfigFactory, AppMenuService, AuthGuardService, CurrencyService, dataServiceFactory, DialogService, LocalStorageService, LoginService, MomentService, NavigationService, NumberService, OModulesInfoService, OntimizeExportService, OntimizeFileService, OntimizeMatIconRegistry, OntimizeService, OntimizeServiceResponseParser, OTranslateService, OUserInfoService, SnackBarService } from '../services';
+import {
+  appConfigFactory,
+  AppMenuService,
+  AuthGuardService,
+  CurrencyService,
+  dataServiceFactory,
+  DialogService,
+  LocalStorageService,
+  LoginService,
+  MomentService,
+  NavigationService,
+  NumberService,
+  OModulesInfoService,
+  OntimizeFileService,
+  OntimizeMatIconRegistry,
+  OntimizeService,
+  OntimizeServiceResponseParser,
+  OTranslateService,
+  OUserInfoService,
+  SnackBarService
+} from '../services';
 import { OFormLayoutManagerService } from '../services/o-form-layout-manager.service';
 import { Error403Component } from '../services/permissions/error403/o-error-403.component';
 import { ORemoteConfigurationService } from '../services/remote-config.service';
@@ -100,10 +121,6 @@ export function getOntimizeFileServiceProvider(injector: Injector) {
   return new OntimizeFileService(injector);
 }
 
-export function getOntimizeExportServiceProvider(injector: Injector) {
-  return new OntimizeExportService(injector);
-}
-
 export function getLoginServiceProvider(injector: Injector) {
   return new LoginService(injector);
 }
@@ -190,11 +207,6 @@ export const ONTIMIZE_PROVIDERS: Provider[] = [
   {
     provide: OntimizeFileService,
     useFactory: getOntimizeFileServiceProvider,
-    deps: [Injector]
-  },
-  {
-    provide: OntimizeExportService,
-    useFactory: getOntimizeExportServiceProvider,
     deps: [Injector]
   },
   // getLoginServiceProvider

--- a/ontimize/services/export-service.provider.ts
+++ b/ontimize/services/export-service.provider.ts
@@ -1,0 +1,27 @@
+import { Injector } from '@angular/core';
+
+import { AppConfig, Config } from '../config/app-config';
+import { OntimizeExportService } from './ontimize-export.service';
+
+export class ExportServiceFactory {
+
+  protected config: Config;
+
+  constructor(protected injector: Injector) {
+    this.config = this.injector.get(AppConfig).getConfiguration();
+  }
+
+  public factory(): any {
+    if (typeof (this.config.exportServiceType) === 'undefined') {
+      return new OntimizeExportService(this.injector);
+    } else {
+      let newInstance = Object.create((this.config.exportServiceType as any).prototype);
+      this.config.exportServiceType.apply(newInstance, [this.injector]);
+      return newInstance;
+    }
+  }
+}
+
+export function exportServiceFactory(injector: Injector) {
+  return new ExportServiceFactory(injector).factory();
+}

--- a/ontimize/services/ontimize-export.service.ts
+++ b/ontimize/services/ontimize-export.service.ts
@@ -6,10 +6,11 @@ import { share } from 'rxjs/operators';
 
 import { AppConfig, Config } from '../config/app-config';
 import { LoginService } from '../services';
+import { IExportService } from '../types/export-service.interface';
 import { Codes, ServiceUtils } from '../utils';
 
 @Injectable()
-export class OntimizeExportService {
+export class OntimizeExportService implements IExportService {
 
   public exportPath: string;
   public downloadPath: string;
@@ -79,19 +80,26 @@ export class OntimizeExportService {
 
     const self = this;
     // TODO: try multipart
-    this.httpClient.post(url, body, options).subscribe((resp: any) => {
-      if (resp && resp.code === Codes.ONTIMIZE_UNAUTHORIZED_CODE) {
-        self.redirectLogin(true);
-      } else if (resp.code === Codes.ONTIMIZE_FAILED_CODE) {
-        _innerObserver.error(resp.message);
-      } else if (resp.code === Codes.ONTIMIZE_SUCCESSFUL_CODE) {
-        _innerObserver.next(resp);
-      } else {
-        // Unknow state -> error
-        _innerObserver.error('Service unavailable');
-      }
-    }, error => _innerObserver.error(error),
-      () => _innerObserver.complete());
+    this.httpClient.post(url, body, options).subscribe(
+      (resp: any) => {
+        if (resp && resp.code === Codes.ONTIMIZE_UNAUTHORIZED_CODE) {
+          self.redirectLogin(true);
+        } else if (resp.code === Codes.ONTIMIZE_FAILED_CODE) {
+          _innerObserver.error(resp.message);
+        } else if (resp.code === Codes.ONTIMIZE_SUCCESSFUL_CODE) {
+          self.downloadFile(resp.data[0][format + 'Id'], format)
+            .subscribe(
+              r => _innerObserver.next(r),
+              e => _innerObserver.error(e),
+              () => _innerObserver.complete()
+            );
+        } else {
+          // Unknow state -> error
+          _innerObserver.error('Service unavailable');
+        }
+      },
+      error => _innerObserver.error(error)
+    );
 
     return dataObservable;
   }
@@ -110,19 +118,21 @@ export class OntimizeExportService {
       'responseType': 'blob'
     };
     // .map((res: any) => new Blob([res.blob()], { type: responseType }))
-    this.httpClient.get(url, options).subscribe((resp: any) => {
-      let fileData = resp.body;
-      let fileURL = URL.createObjectURL(fileData);
-      let a = document.createElement('a');
-      document.body.appendChild(a);
-      a.href = fileURL;
-      a.download = fileId + '.' + fileExtension;
-      a.click();
-      document.body.removeChild(a);
-      _innerObserver.next(fileData);
-      URL.revokeObjectURL(fileURL);
-    }, error => _innerObserver.error(error),
-      () => _innerObserver.complete());
+    this.httpClient.get(url, options).subscribe(
+      (resp: any) => {
+        let fileData = resp.body;
+        let fileURL = URL.createObjectURL(fileData);
+        let a = document.createElement('a');
+        document.body.appendChild(a);
+        a.href = fileURL;
+        a.download = fileId + '.' + fileExtension;
+        a.click();
+        document.body.removeChild(a);
+        _innerObserver.next(fileData);
+        URL.revokeObjectURL(fileURL);
+      }, error => _innerObserver.error(error),
+      () => _innerObserver.complete()
+    );
 
     return dataObservable;
   }

--- a/ontimize/types.ts
+++ b/ontimize/types.ts
@@ -1,2 +1,3 @@
+export * from './types/export-service.interface';
 export * from './types/ontimize-service-config.type';
 export * from './types/remote-configuration.type';

--- a/ontimize/types/export-service.interface.ts
+++ b/ontimize/types/export-service.interface.ts
@@ -1,0 +1,7 @@
+import { Observable } from 'rxjs';
+
+export interface IExportService {
+  getDefaultServiceConfiguration(serviceName?: string): any;
+  configureService(config: any, modeAll?: boolean): void;
+  exportData(data: any, format: string, entity?: string): Observable<any>;
+}


### PR DESCRIPTION
- New attribute `exportServiceType` configurable in the application configuration file, it allows configuring the service used for exportation in the whole application.
- New attribute `export-service-type` for `o-table` component.

Both parameters allow the developer to extend the default exportation service or to create his own by implementing the `IExportService` interface. Related to #326. Closes #327