### PR TITLE
Bugfix/4.x.x language selector not emitting onchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 * **o-time-input**: Fix bad behaviour when there is more than one component in the same form ([fc1dd47](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fc1dd47))
+* **o-language-selector**: emit `onChange` event ([231c1d4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/231c1d4))
 
 ## 4.1.2 (2020-02-26)
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * new attribute `visible-export-dialog-buttons` ([#320](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/320)). Closes [#316](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/316)
   * new attribute `export-service-type` ([0f2db1c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0f2db1c))
 * **App configuration**: new attribute `exportServiceType` allows configuring the service used for exportation in the whole application ([c785371](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c785371))
+* Now the application language is stored in the browser and loaded on application startup ([e9b9535](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e9b9535))
 
 ### Bug Fixes
 * **o-time-input**: Fix bad behaviour when there is more than one component in the same form ([fc1dd47](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fc1dd47))

--- a/ontimize/components/language-selector/o-language-selector.component.ts
+++ b/ontimize/components/language-selector/o-language-selector.component.ts
@@ -60,6 +60,7 @@ export class OLanguageSelectorComponent {
   configureI18n(lang: any) {
     if (this.translateService && this.translateService.getCurrentLang() !== lang) {
       this.translateService.use(lang);
+      this.onChange.emit(lang);
     }
   }
 

--- a/ontimize/config/o-providers.ts
+++ b/ontimize/config/o-providers.ts
@@ -50,23 +50,34 @@ export function appInitializerFactory(injector: Injector, config: Config, oTrans
     let observableArray = [];
     const locationInitialized = injector.get(LOCATION_INITIALIZED, Promise.resolve(null));
     locationInitialized.then(() => {
-      oTranslate.setDefaultLang('en');
-      let userLang = config['locale'];
-      if (!userLang) {
-        // use navigator lang if available
-        userLang = oTranslate.getBrowserLang();
+      const storedLang = oTranslate.getStoredLanguage();
+      const configLang = config['locale'];
+      const browserLang = oTranslate.getBrowserLang();
+      let userLang = 'en';
+      let defaultLang = 'en';
+      if (storedLang) {
+        userLang = storedLang;
+      } else if (configLang) {
+        userLang = configLang;
+        defaultLang = configLang;
+      } else if (browserLang) {
+        userLang = browserLang;
+        defaultLang = browserLang;
       }
+      oTranslate.setDefaultLang(defaultLang);
+
+      const locales = new Set(config.applicationLocales || []);
+      locales.add('en');
+      locales.add(userLang);
+
+      const localseArray = [];
+      locales.forEach((val1, val2, self) => localseArray.push(val1));
 
       // initialize available locales array if needed
       if (!config.applicationLocales) {
-        config.applicationLocales = [];
+        config.applicationLocales = localseArray; // use [...locales] with es6
       }
-      if (config.applicationLocales.indexOf('en') === -1) {
-        config.applicationLocales.push('en');
-      }
-      if (userLang && config.applicationLocales.indexOf(userLang) === -1) {
-        config.applicationLocales.push(userLang);
-      }
+
       if (config['uuid'] === undefined || config['uuid'] === null || config['uuid'] === '') {
         console.error('Your app must have an \'uuid\' property defined on your app.config file. Otherwise, your application will not work correctly.');
         alert('Your app must have an \'uuid\' property defined on your app.config file. Otherwise, your application will not work correctly.');

--- a/ontimize/util/codes.ts
+++ b/ontimize/util/codes.ts
@@ -48,6 +48,7 @@ export class Codes {
   public static QUERY_PARAMS = 'queryParams';
   public static IS_DETAIL = 'isdetail';
 
+  public static LANGUAGE_KEY = 'lang';
   public static SESSION_KEY = 'session';
   public static SESSION_EXPIRED_KEY = 'session-expired';
 


### PR DESCRIPTION
- Component `o-language-selector` emits `onChange` event correctly
- Language is stored in localstorage when the language changes and loaded on application startup