### PR TITLE
Fixed the loading not removed in form-layout-tabgroup 

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/services/navigation.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/navigation.service.ts
@@ -36,6 +36,7 @@ export class ONavigationItem {
     this.text = value.text ? value.text : '';
     this.displayText = value.displayText ? value.displayText : '';
     this.formRoutes = value.formRoutes;
+    this.formLayoutRoutes = value.formLayoutRoutes;
     this.activeFormMode = value.activeFormMode;
     this.keysValues = value.keysValues;
     this.queryConfiguration = value.queryConfiguration;


### PR DESCRIPTION
Fixed the loading not removed in form-layout-tabgroup when there is a insertion tab when return in navigation