### PR TITLE
[Bugfix/8.x.x ] Including parent keys value when exporting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 * **base-service.class**: fixing bug in delete method headers ([d4065cdd](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/d4065cdd)) ([#361](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/361))
 * **o-combo**: scroll not worked when searchable="yes" ([b70b2a1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b70b2a1)) Closes [#365](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/365)
+* **OServiceBaseComponent**: fixing bug including parent-keys value in filter when exporting data ([d34280f](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/d34280f9086ef8e2107367327e6724fd0c666501)) Closes [#373](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/373)
 
 ### BREAKING CHANGES
 * **o-app-layout**: the menu icon appears in sidenav when mode="desktop" and show-header="yes". ([#364](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/364)) Closes [#316](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/363)

--- a/projects/ontimize-web-ngx/src/lib/components/o-service-base-component.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/o-service-base-component.class.ts
@@ -363,7 +363,6 @@ export class OServiceBaseComponent implements ILocalStorageComponent, OnChanges 
     if (!ServiceUtils.filterContainsAllParentKeys(filterParentKeys, this._pKeysEquiv) && !this.queryWithNullParentKeys) {
       this.setData([], []);
     } else {
-      filter = Object.assign(filter || {}, filterParentKeys);
       const queryArguments = this.getQueryArguments(filter, ovrrArgs);
       if (this.querySubscription) {
         this.querySubscription.unsubscribe();
@@ -497,6 +496,8 @@ export class OServiceBaseComponent implements ILocalStorageComponent, OnChanges 
   }
 
   getComponentFilter(existingFilter: any = {}): any {
+    const filterParentKeys = ServiceUtils.getParentKeysFromForm(this._pKeysEquiv, this.form);
+    existingFilter = Object.assign(existingFilter || {}, filterParentKeys);
     return existingFilter;
   }
 


### PR DESCRIPTION
The parent keys value was only added from _queryData()_ method. Now this piece of code is included in method _getComponentFilter()_, in that way when you call this method you retrieve all available filter values of the component.