### PR TITLE
[Bugfix/4.x.x] Including parent keys value when exporting data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 * **o-time-input**: Fix bad behaviour when there is more than one component in the same form ([fc1dd47](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/fc1dd47))
+* **OServiceBaseComponent**: fixing bug including parent-keys value in filter when exporting data ([78877d8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/78877d8b4d01710a3a1d4353a8b293d795adc6e6)) Closes [#373](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/373)
 
 ## 4.1.2 (2020-02-26)
 ### Features

--- a/ontimize/components/o-service-base-component.class.ts
+++ b/ontimize/components/o-service-base-component.class.ts
@@ -359,7 +359,6 @@ export class OServiceBaseComponent implements ILocalStorageComponent {
     if (!ServiceUtils.filterContainsAllParentKeys(filterParentKeys, this._pKeysEquiv) && !this.queryWithNullParentKeys) {
       this.setData([], []);
     } else {
-      filter = Object.assign(filter || {}, filterParentKeys);
       let queryArguments = this.getQueryArguments(filter, ovrrArgs);
       if (this.querySubscription) {
         this.querySubscription.unsubscribe();
@@ -491,6 +490,8 @@ export class OServiceBaseComponent implements ILocalStorageComponent {
   }
 
   getComponentFilter(existingFilter: any = {}): any {
+    const filterParentKeys = ServiceUtils.getParentKeysFromForm(this._pKeysEquiv, this.form);
+    existingFilter = Object.assign(existingFilter || {}, filterParentKeys);
     return existingFilter;
   }
 


### PR DESCRIPTION
The parent keys value was only added from _queryData()_ method. Now this piece of code is included in method _getComponentFilter()_, in that way when you call this method you retrieve all available filter values of the component.