### PR TITLE
Form toolbar action methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.0.1
+### Features
+* **o-form**:
+  * new public methods `back`, `closeDetail`, `reload`, `goInsertMode`, `insert`, `goEditMode`, `update`, `undo` and `delete` ([e5c899d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e5c899d)).
+  * The following methods has been deprecated and will be removed in the future: `_backAction`, `_closeDetailAction`, `_reloadAction`, `_goInsertMode`, `_insertAction`, `_goEditMode`, `_editAction`, `_undoLastChangeAction` and `_deleteAction` ([e5c899d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e5c899d)).
+
 ## 8.0.0 (2020-08-20)
 ### Bug Fixes
 * **o-checkbox** : fixing bug in sql-type value was always overwritted by VARCHAR ([b9f6cbb](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b9f6cbb))

--- a/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
@@ -312,7 +312,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
       if (Util.isArray(valArr) && valArr.length === 2 && !self.isInInsertMode()) {
         const valArrValues = valArr[0] === true && valArr[1] === true;
         if (self.queryOnInit && valArrValues) {
-          self._reloadAction(true);
+          self.reload(true);
         } else {
           self.initializeFields();
         }
@@ -522,15 +522,15 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   executeToolbarAction(action: string, options?: any) {
     switch (action) {
-      case Codes.BACK_ACTION: this._backAction(); break;
-      case Codes.CLOSE_DETAIL_ACTION: this._closeDetailAction(options); break;
-      case Codes.RELOAD_ACTION: this._reloadAction(true); break;
-      case Codes.GO_INSERT_ACTION: this._goInsertMode(options); break;
-      case Codes.INSERT_ACTION: this._insertAction(); break;
-      case Codes.GO_EDIT_ACTION: this._goEditMode(options); break;
-      case Codes.EDIT_ACTION: this._editAction(); break;
-      case Codes.UNDO_LAST_CHANGE_ACTION: this._undoLastChangeAction(); break;
-      case Codes.DELETE_ACTION: return this._deleteAction();
+      case Codes.BACK_ACTION: this.back(); break;
+      case Codes.CLOSE_DETAIL_ACTION: this.closeDetail(options); break;
+      case Codes.RELOAD_ACTION: this.reload(true); break;
+      case Codes.GO_INSERT_ACTION: this.goInsertMode(options); break;
+      case Codes.INSERT_ACTION: this.insert(); break;
+      case Codes.GO_EDIT_ACTION: this.goEditMode(options); break;
+      case Codes.EDIT_ACTION: this.update(); break;
+      case Codes.UNDO_LAST_CHANGE_ACTION: this.undo(); break;
+      case Codes.DELETE_ACTION: return this.delete();
       default: break;
     }
     return undefined;
@@ -766,11 +766,33 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
     this.onDataLoaded.emit(data);
   }
 
+  /**
+   * @deprecated Use `back()` instead
+   */
   _backAction() {
+    console.warn('Method `OFormComponent._backAction` is deprecated and will be removed in the furute. Use `back` instead');
     this.formNavigation.navigateBack();
   }
 
+  /**
+   * Navigate back
+   */
+  back() {
+    this.formNavigation.navigateBack();
+  }
+
+  /**
+   * @deprecated Use `closeDetail(options?: any)` instead
+   */
   _closeDetailAction(options?: any) {
+    console.warn('Method `OFormComponent._closeDetailAction` is deprecated and will be removed in the furute. Use `closeDetail` instead');
+    this.formNavigation.closeDetailAction(options);
+  }
+
+  /**
+   * Close current detail form
+   */
+  closeDetail(options?: any) {
     this.formNavigation.closeDetailAction(options);
   }
 
@@ -778,7 +800,22 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
     this.formNavigation.stayInRecordAfterInsert(insertedKeys);
   }
 
+  /**
+   * @deprecated Use `reload(useFilter: boolean = false)` instead
+   */
   _reloadAction(useFilter: boolean = false) {
+    console.warn('Method `OFormComponent._reloadAction` is deprecated and will be removed in the furute. Use `reload` instead');
+    let filter = {};
+    if (useFilter) {
+      filter = this.getCurrentKeysValues();
+    }
+    this.queryData(filter);
+  }
+
+  /**
+   * Reload the form data
+   */
+  reload(useFilter: boolean = false) {
     let filter = {};
     if (useFilter) {
       filter = this.getCurrentKeysValues();
@@ -788,8 +825,17 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Navigates to 'insert' mode
+   * @deprecated Use `goInsertMode(options?: any)` instead
    */
   _goInsertMode(options?: any) {
+    console.warn('Method `OFormComponent._goInsertMode` is deprecated and will be removed in the furute. Use `goInsertMode` instead');
+    this.formNavigation.goInsertMode(options);
+  }
+
+  /**
+   * Navigates to 'insert' mode
+   */
+  goInsertMode(options?: any) {
     this.formNavigation.goInsertMode(options);
   }
 
@@ -800,8 +846,10 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Performs insert action.
+   * @deprecated Use `insert()` instead
    */
   _insertAction() {
+    console.warn('Method `OFormComponent._insertAction` is deprecated and will be removed in the furute. Use `insert` instead');
     Object.keys(this.formGroup.controls).forEach((control) => {
       this.formGroup.controls[control].markAsTouched();
     });
@@ -823,7 +871,39 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
       } else if (self.afterInsertMode === 'new') {
         this._clearFormAfterInsert();
       } else {
-        self._closeDetailAction();
+        self.closeDetail();
+      }
+    }, error => {
+      self.postIncorrectInsert(error);
+    });
+  }
+
+  /**
+   * Performs insert action.
+   */
+  insert() {
+    Object.keys(this.formGroup.controls).forEach((control) => {
+      this.formGroup.controls[control].markAsTouched();
+    });
+
+    if (!this.formGroup.valid) {
+      this.dialogService.alert('ERROR', 'MESSAGES.FORM_VALIDATION_ERROR');
+      return;
+    }
+
+    const self = this;
+    const values = this.getAttributesValuesToInsert();
+    const sqlTypes = this.getAttributesSQLTypes();
+    this.insertData(values, sqlTypes).subscribe(resp => {
+      self.postCorrectInsert(resp);
+      self.formCache.setCacheSnapshot();
+      self.markFormLayoutManagerToUpdate();
+      if (self.afterInsertMode === 'detail') {
+        self._stayInRecordAfterInsert(resp);
+      } else if (self.afterInsertMode === 'new') {
+        this._clearFormAfterInsert();
+      } else {
+        self.closeDetail();
       }
     }, error => {
       self.postIncorrectInsert(error);
@@ -832,15 +912,26 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Navigates to 'edit' mode
+   * @deprecated Use `goEditMode(options?: any)` instead
    */
   _goEditMode(options?: any) {
+    console.warn('Method `OFormComponent._goEditMode` is deprecated and will be removed in the furute. Use `goEditMode` instead');
+    this.formNavigation.goEditMode();
+  }
+
+  /**
+   * Navigates to 'edit' mode
+   */
+  goEditMode(options?: any) {
     this.formNavigation.goEditMode();
   }
 
   /**
    * Performs 'edit' action
+   * @deprecated Use `update()` instead
    */
   _editAction() {
+    console.warn('Method `OFormComponent._editAction` is deprecated and will be removed in the furute. Use `update` instead');
     Object.keys(this.formGroup.controls).forEach(
       (control) => {
         this.formGroup.controls[control].markAsTouched();
@@ -872,9 +963,53 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
       self.formCache.setCacheSnapshot();
       self.markFormLayoutManagerToUpdate();
       if (self.stayInRecordAfterEdit) {
-        self._reloadAction(true);
+        self.reload(true);
       } else {
-        self._closeDetailAction();
+        self.closeDetail();
+      }
+    }, error => {
+      self.postIncorrectUpdate(error);
+    });
+  }
+
+  /**
+   * Performs 'edit' action
+   */
+  update() {
+    Object.keys(this.formGroup.controls).forEach(
+      (control) => {
+        this.formGroup.controls[control].markAsTouched();
+      }
+    );
+
+    if (!this.formGroup.valid) {
+      this.dialogService.alert('ERROR', 'MESSAGES.FORM_VALIDATION_ERROR');
+      return;
+    }
+
+    // retrieving keys...
+    const self = this;
+    const filter = this.getKeysValues();
+
+    // retrieving values to update...
+    const values = this.getAttributesValuesToUpdate();
+    const sqlTypes = this.getAttributesSQLTypes();
+
+    if (Object.keys(values).length === 0) {
+      // Nothing to update
+      this.dialogService.alert('INFO', 'MESSAGES.FORM_NOTHING_TO_UPDATE_INFO');
+      return;
+    }
+
+    // invoke update method...
+    this.updateData(filter, values, sqlTypes).subscribe(resp => {
+      self.postCorrectUpdate(resp);
+      self.formCache.setCacheSnapshot();
+      self.markFormLayoutManagerToUpdate();
+      if (self.stayInRecordAfterEdit) {
+        self.reload(true);
+      } else {
+        self.closeDetail();
       }
     }, error => {
       self.postIncorrectUpdate(error);
@@ -883,8 +1018,18 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Performs 'delete' action
+   * @deprecated Use `delete()` instead
    */
   _deleteAction() {
+    console.warn('Method `OFormComponent._deleteAction` is deprecated and will be removed in the furute. Use `delete` instead');
+    const filter = this.getKeysValues();
+    return this.deleteData(filter);
+  }
+
+  /**
+   * Performs 'delete' action
+   */
+  delete() {
     const filter = this.getKeysValues();
     return this.deleteData(filter);
   }
@@ -1173,7 +1318,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
       if (res) {
         self.refreshComponentsEditableState();
         if (!self.isInInsertMode() && self.queryOnInit) {
-          self._reloadAction(true);
+          self.reload(true);
         }
         if (self.formParentKeysValues) {
           Object.keys(self.formParentKeysValues).forEach(parentKey => {
@@ -1245,7 +1390,18 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
     return this.formCache.isInitialStateChanged();
   }
 
+  /**
+   * @deprecated Use `undo()` instead
+   */
   _undoLastChangeAction() {
+    console.warn('Method `OFormComponent._undoLastChangeAction` is deprecated and will be removed in the furute. Use `undo` instead');
+    this.formCache.undoLastChange();
+  }
+
+  /**
+   * Undo last change
+   */
+  undo() {
     this.formCache.undoLastChange();
   }
 
@@ -1285,7 +1441,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   setUrlParamsAndReload(val: object) {
     this.formNavigation.setUrlParams(val);
-    this._reloadAction(true);
+    this.reload(true);
   }
 
   getRegisteredFieldsValues() {
@@ -1302,7 +1458,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Return the current value of the control in the form
-   * @param attr
+   * @param attr the attr of the form field
    */
   getFieldValue(attr: string): any {
     let value = null;
@@ -1315,14 +1471,11 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Return an object with the values of each attribute
-   * @param attrs
+   * @param attrs the attr's of the form fields
    */
   getFieldValues(attrs: string[]): any {
-    const self = this;
     const arr = {};
-    attrs.forEach((key) => {
-      arr[key] = self.getFieldValue(key);
-    });
+    attrs.forEach(key => arr[key] = this.getFieldValue(key));
     return arr;
 
   }
@@ -1341,7 +1494,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Sets the value of each control in the form.
-   * @param values
+   * @param values the values
    */
   setFieldValues(values: any, options?: FormValueOptions) {
     for (const key in values) {
@@ -1353,7 +1506,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Clear the value of each control in the form
-   * @param attr
+   * @param attr the attr of the form field
    */
   clearFieldValue(attr: string, options?: FormValueOptions) {
     const comp = this.getFieldReference(attr);
@@ -1364,7 +1517,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Reset the value of each control in the form
-   * @param attrs
+   * @param attrs the attr's of the form fields
    */
   clearFieldValues(attrs: string[], options?: FormValueOptions) {
     const self = this;
@@ -1375,14 +1528,15 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Retrieves the reference of the control in the form.
-   * @param attr
+   * @param attr the attr of the form field
    */
   getFieldReference(attr: string): IFormDataComponent {
     return this._components[attr];
   }
+
   /**
    * Retrieves the reference of each control in the form
-   * @param attrs
+   * @param attrs the attr's of the form fileds
    */
   getFieldReferences(attrs: string[]): IFormDataComponentHash {
     const arr: IFormDataComponentHash = {};


### PR DESCRIPTION
- Deprecated old methods for the form toolbar actions
- Created new methods for the form toolbar actions with improved naming
- Added warnings in old methods for preventing users use them