### PR TITLE
[4.x.x] Fixed bug in width columns table

### DIFF
--- a/ontimize/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.ts
+++ b/ontimize/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.ts
@@ -112,8 +112,9 @@ export class OTableColumnResizerComponent implements OnInit, OnDestroy {
     if (!Util.isDefined(this.headerEl)) {
       return;
     }
+    const DOMWidth = this.table.getClientWidthColumn(this.column);
     this.startX = startEvent.screenX;
-    this.startWidth = this.column.DOMWidth;
+    this.startWidth = DOMWidth;
     this.minWidth = this.column.getMinWidthValue();
     this.initializeWidthData();
     this.ngZone.runOutsideAngular(() => {
@@ -186,11 +187,12 @@ export class OTableColumnResizerComponent implements OnInit, OnDestroy {
     this.blockedMaxCols = [];
     const columns = [this.column, ...this.nextOColumns];
     columns.forEach(oCol => {
-      if (oCol.DOMWidth <= oCol.getMinWidthValue()) {
+      const DOMWidth = this.table.getClientWidthColumn(oCol);
+      if (DOMWidth <= oCol.getMinWidthValue()) {
         self.blockedMinCols.push(oCol.attr);
       }
       const maxW = oCol.getMaxWidthValue();
-      if (Util.isDefined(maxW) && oCol.DOMWidth >= maxW) {
+      if (Util.isDefined(maxW) && DOMWidth >= maxW) {
         self.blockedMaxCols.push(oCol.attr);
       }
     });
@@ -230,17 +232,19 @@ export class OTableColumnResizerComponent implements OnInit, OnDestroy {
     if (widthRatio > 0 && this.blockedMaxCols.length < this.nextOColumns.length) {
       let cols = this.nextOColumns.filter((oCol: OColumn) => this.blockedMaxCols.indexOf(oCol.attr) === -1);
       cols.forEach(oCol => {
-        let newWidth = (this.columnsStartWidth[oCol.attr] + widthRatio);
+        let newWidthValue = (this.columnsStartWidth[oCol.attr] + widthRatio);
         let maxWidth = oCol.getMaxWidthValue();
-        if (maxWidth && newWidth > maxWidth) {
-          const diff = newWidth - maxWidth;
-          newWidth = maxWidth;
+        if (maxWidth && newWidthValue > maxWidth) {
+          const diff = newWidthValue - maxWidth;
+          newWidthValue = maxWidth;
           this.blockedMaxCols.push(oCol.attr);
           const notBlocked = this.nextOColumns.length - this.blockedMaxCols.length;
           widthRatio += notBlocked > 0 ? Math.floor(diff / notBlocked) : 0;
         }
-        widthDifference += newWidth - oCol.DOMWidth;
-        oCol.setWidth(newWidth);
+
+        const DOMWidth = this.table.getClientWidthColumn(oCol);
+        widthDifference += newWidthValue - DOMWidth;
+        oCol.setWidth(newWidthValue);
       });
     }
     const newWidth = Math.min(this.startWidth - widthDifference, newColumnWidth);
@@ -252,9 +256,9 @@ export class OTableColumnResizerComponent implements OnInit, OnDestroy {
     let nextColMinWidthAcum = 0;
     let nextColWidthAcum = 0;
     this.nextOColumns.forEach((col: OColumn) => {
-      nextColMinWidthAcum += col.getMinWidthValue();
-      nextColWidthAcum += col.DOMWidth;
-      this.columnsStartWidth[col.attr] = col.DOMWidth;
+      const DOMWidth = this.table.getClientWidthColumn(col);
+      nextColWidthAcum += DOMWidth;
+      this.columnsStartWidth[col.attr] = DOMWidth;
     });
     const calcMaxWidth = this.headerEl.clientWidth + (nextColWidthAcum - nextColMinWidthAcum);
     if (Util.isDefined(maxWidth)) {

--- a/ontimize/components/table/o-table.component.html
+++ b/ontimize/components/table/o-table.component.html
@@ -68,7 +68,7 @@
         <ng-container *ngFor="let column of oTableOptions.columns" [matColumnDef]="column.name">
           <!--Define header-cell-->
 
-          <th mat-header-cell *matHeaderCellDef [ngClass]="getTitleAlignClass(column)" [style.width]="column.getRenderWidth(horizontalScroll)"
+          <th mat-header-cell *matHeaderCellDef [ngClass]="getTitleAlignClass(column)" [style.width]="column.getRenderWidth(horizontalScroll,this.getClientWidthColumn(column))"
             [class.resizable]="resizable">
 
             <mat-icon *ngIf="isModeColumnFilterable(column)" class="column-filter-icon"
@@ -93,7 +93,7 @@
             [class.empty-cell]="isEmpty(row[column.name])" [matTooltipDisabled]="!column.hasTooltip()" [matTooltip]="column.getTooltip(row)"
             matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
             [class.o-mat-cell-multiline]="(column.isMultiline | async)" [oContextMenu]="tableContextMenu"
-            [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}" [style.width]="column.getRenderWidth(horizontalScroll)">
+            [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}" [style.width]="column.getRenderWidth(horizontalScroll,this.getClientWidthColumn(column))">
             <ng-container *ngIf="usePlainRender(column, row); else cellRender">
               {{ row[column.name] }}
             </ng-container>

--- a/ontimize/components/table/o-table.component.scss
+++ b/ontimize/components/table/o-table.component.scss
@@ -40,8 +40,8 @@ $o_table_row_padding: 24px;
     &.block-events {
       pointer-events: none;
 
-       > .o-table-body .mat-header-row,
-      > .toolbar {
+       > .toolbar,
+      > .o-table-body .mat-header-row {
         opacity: .75;
       }
     }
@@ -96,7 +96,9 @@ $o_table_row_padding: 24px;
       }
 
       &.horizontal-scroll {
-        overflow-x: auto;
+        .o-table-overflow {
+          overflow-x: auto;
+        }
         padding-bottom: 16px;
 
         .mat-header-cell {
@@ -107,8 +109,9 @@ $o_table_row_padding: 24px;
       .o-table-no-results {
         cursor: default;
         text-align: center;
-        td{
-          text-align: center
+
+        td {
+          text-align: center;
         }
       }
     }
@@ -453,7 +456,6 @@ $o_table_row_padding: 24px;
 
       .o-table-overflow {
         flex: 1;
-        overflow: auto;
       }
     }
   }

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -644,9 +644,6 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
   @InputConverter()
   set horizontalScroll(value: boolean) {
     this._horizontalScroll = BooleanConverter(value);
-    // this._oTableOptions.columns.filter(c => c.visible).forEach((c) => {
-    //   c.DOMWidth = undefined;
-    // });
     this.refreshColumnsWidth();
   }
 

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -373,18 +373,18 @@ export class OColumn {
     return value ? value : undefined;
   }
 
-  getRenderWidth(horizontalScrolled?: boolean) {
+  getRenderWidth(horizontalScrolled: boolean, clientWidth: number) {
     if (Util.isDefined(this.width)) {
       return this.width;
     }
     const minValue = Util.extractPixelsValue(this.minWidth, OTableComponent.DEFAULT_COLUMN_MIN_WIDTH);
-    if (Util.isDefined(minValue) && this.DOMWidth < minValue) {
+    if (Util.isDefined(minValue) && clientWidth < minValue) {
       this.DOMWidth = minValue;
     }
 
     if (Util.isDefined(this.maxWidth)) {
       const maxValue = Util.extractPixelsValue(this.maxWidth);
-      if (Util.isDefined(maxValue) && this.DOMWidth > maxValue) {
+      if (Util.isDefined(maxValue) && clientWidth > maxValue) {
         this.DOMWidth = maxValue;
       }
     }
@@ -639,8 +639,21 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
   showTitle: boolean = false;
   protected editionMode: string = Codes.DETAIL_MODE_NONE;
   protected selectionMode: string = Codes.SELECTION_MODE_MULTIPLE;
+
+  protected _horizontalScroll: boolean = false;
   @InputConverter()
-  horizontalScroll: boolean = false;
+  set horizontalScroll(value: boolean) {
+    this._horizontalScroll = BooleanConverter(value);
+    // this._oTableOptions.columns.filter(c => c.visible).forEach((c) => {
+    //   c.DOMWidth = undefined;
+    // });
+    this.refreshColumnsWidth();
+  }
+
+  get horizontalScroll(): boolean {
+    return this._horizontalScroll;
+  }
+
   @InputConverter()
   showPaginatorFirstLastButtons: boolean = true;
   @InputConverter()
@@ -1649,8 +1662,6 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
       ObservableWrapper.callEmit(this.onContentChange, this.dataSource.renderedData);
       this.previousRendererData = this.dataSource.renderedData;
     }
-
-    this.getColumnsWidthFromDOM();
 
     if (this.state.hasOwnProperty('selection') && this.dataSource.renderedData.length > 0 && this.getSelectedItems().length === 0) {
       this.state.selection.forEach(selectedItem => {
@@ -2741,32 +2752,35 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
     return !this.isSelectionModeNone() && this.selection.isSelected(row);
   }
 
-  protected getColumnsWidthFromDOM() {
-    if (Util.isDefined(this.tableHeaderEl)) {
-      [].slice.call(this.tableHeaderEl.nativeElement.children).forEach(thEl => {
-        const oCol: OColumn = this.getOColumnFromTh(thEl);
-        if (Util.isDefined(oCol) && thEl.clientWidth > 0 && oCol.DOMWidth !== thEl.clientWidth) {
-          oCol.DOMWidth = thEl.clientWidth;
-        }
-      });
+  getThWidthFromOColumn(oColumn: OColumn): any {
+    let widthColumn: number;
+    const thArray = [].slice.call(this.tableHeaderEl.nativeElement.children);
+    for (const th of thArray) {
+      const classList: any[] = [].slice.call((th as Element).classList);
+      const columnClass = classList.find((className: string) => (className === 'mat-column-' + oColumn.attr));
+      if (columnClass && columnClass.length > 1) {
+        widthColumn = th.clientWidth;
+        break;
+      }
     }
+    return widthColumn;
   }
 
   refreshColumnsWidth() {
-    this._oTableOptions.columns.filter(c => c.visible).forEach((c) => {
-      c.DOMWidth = undefined;
-    });
-    this.cd.detectChanges();
+
     setTimeout(() => {
-      this.getColumnsWidthFromDOM();
       this._oTableOptions.columns.filter(c => c.visible).forEach(c => {
-        if (Util.isDefined(c.definition) && Util.isDefined(c.definition.width) && this.horizontalScroll) {
+        if (Util.isDefined(c.definition) && Util.isDefined(c.definition.width)) {
           c.width = c.definition.width;
         }
-        c.getRenderWidth(this.horizontalScroll);
+        c.getRenderWidth(this.horizontalScroll, this.getClientWidthColumn(c));
       });
       this.cd.detectChanges();
     }, 0);
+  }
+
+  public getClientWidthColumn(col: OColumn): number {
+    return col.DOMWidth || this.getThWidthFromOColumn(col);
   }
 }
 


### PR DESCRIPTION
1. Fixed the bug when a table column has width configured
2. Column width value is not recalculate when windows are resized (the default value will be auto) and the column autoadjust on the table
3. Columns width in the table is refreshing when horizontal-scroll input is changed