### PR TITLE
[8.x.x] Indicator numbered position

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header-column-filter-icon/o-table-header-column-filter-icon.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header-column-filter-icon/o-table-header-column-filter-icon.component.scss
@@ -5,8 +5,8 @@
     left: 0;
 
     .o-table-header-indicator-numbered {
-      bottom: -12px;
-      right: -6px;
+      right: -5px;
+      bottom: -8px;
     }
   }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/sort/sort-header.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/sort/sort-header.scss
@@ -43,10 +43,7 @@ $mat-sort-header-arrow-hint-opacity: .38;
   }
 
   .o-mat-sort-indicator-numbered-desc {
-    top: -12px;
-  }
-  .o-mat-sort-indicator-numbered-asc {
-    bottom: -12px;
+    top: -8px;
   }
 }
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -73,7 +73,7 @@
           <!--Define header-cell-->
 
           <th mat-header-cell *matHeaderCellDef [ngClass]="getTitleAlignClass(column)" [class.resizable]="resizable"
-            [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="column.minWidth"
+            [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="getMinWidthColumn(column)"
             [style.max-width]="column.maxWidth">
             <div class="content">
               <o-table-header-column-filter-icon *ngIf="isModeColumnFilterable(column)" [column]="column"></o-table-header-column-filter-icon>
@@ -96,7 +96,7 @@
             matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
             [class.o-mat-cell-multiline]="(column.isMultiline | async)" [oContextMenu]="tableContextMenu"
             [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}"
-            [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="column.minWidth"
+            [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="getMinWidthColumn(column)"
             [style.max-width]="column.maxWidth">
             <div class="content">
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -169,10 +169,7 @@ $o_table_row_padding: 24px;
       }
 
       &.medium {
-        .column-filter-icon {
-          margin-top: 4px;
-        }
-
+        .column-filter-icon,
         .mat-sort-header-arrow {
           margin-top: 6px;
         }
@@ -340,7 +337,7 @@ $o_table_row_padding: 24px;
         }
 
         .o-table-header-indicator-numbered {
-          font-size: 9px;
+          font-size: 8px;
           position: absolute;
           right: -8px;
           text-align: center;
@@ -352,14 +349,16 @@ $o_table_row_padding: 24px;
           white-space: nowrap;
           text-overflow: ellipsis;
           pointer-events: none;
+          bottom: -10px;
+          right: -9px;
         }
 
         .column-filter-icon {
           cursor: pointer;
           float: left;
-          font-size: 20px;
-          width: 20px;
-          height: 20px;
+          font-size: 18px;
+          width: 18px;
+          height: 18px;
           margin-right: 2px;
           line-height: 1;
         }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -324,8 +324,7 @@ $o_table_row_padding: 24px;
           padding-right: 24px;
         }
 
-        &:first-of-type,
-        &:last-of-type {
+        &:first-of-type{
           padding-left: 0;
           padding-right: 0;
         }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -2505,4 +2505,8 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
     return col.DOMWidth || this.getThWidthFromOColumn(col);
   }
 
+  public getMinWidthColumn(col: OColumn): string {
+    return Util.extractPixelsValue(col.minWidth, Codes.DEFAULT_COLUMN_MIN_WIDTH) + 'px';
+  }
+
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/styles/o-table-theme.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/styles/o-table-theme.scss
@@ -37,8 +37,6 @@
           }
 
           .o-table-header-indicator-numbered {
-            bottom: -12px;
-            right: -6px;
             color: mat-color($foreground, secondary-text);
           }
         }


### PR DESCRIPTION

1. Fixed the position of the numbered indicator from filtering with differents row-height values
2. Fixed text overlapping with filter button in last column
3. Fixed that the min-width value is set by default 80px if it does not have value