### PR TITLE
[8.x.x] Issue 541

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 * **o-list**: use `sort-columns` attribute value on the first query ([3a0cf8a](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/3a0cf8a)) Closes ([#536](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/536))
 * **o-slide-toggle**: fixed getValue function ([d386f4d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/d386f4d)) Closes ([#535](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/535))
+* **o-table-row-expandable**: no expand button in row break example ([8e89988](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/8e89988)) Closes ([#541](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/541))
 
 ## 8.2.0 (2021-02-26)
 ### Features

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -250,10 +250,16 @@
         </ng-container>
 
         <tr #tableHeader mat-header-row *matHeaderRowDef="oTableOptions.visibleColumns; sticky: fixedHeader"></tr>
-
-        <tr mat-row oTableRow *matRowDef="let row; columns: oTableOptions.visibleColumns;  when:isNotGroup; let i = index"
-          [class.selected]="isRowSelected(row)" [ngClass]="row | oTableRowClass: i: rowClass">
-        </tr>
+        <ng-container *ngIf="table.multiTemplateDataRows">
+          <tr mat-row oTableRow *matRowDef="let row; columns: oTableOptions.visibleColumns;  when:isNotGroup; let rowIndex = dataIndex"
+            [class.selected]="isRowSelected(row)" [ngClass]="row | oTableRowClass: rowIndex: rowClass">
+          </tr>
+        </ng-container>
+        <ng-container *ngIf="!table.multiTemplateDataRows">
+          <tr mat-row oTableRow *matRowDef="let row; columns: oTableOptions.visibleColumns;  when:isNotGroup; let rowIndex = index"
+            [class.selected]="isRowSelected(row)" [ngClass]="row | oTableRowClass: rowIndex: rowClass">
+          </tr>
+        </ng-container>
 
         <!-- Row Group header -->
         <tr mat-row *matRowDef="let row; columns: ['groupHeader']; when: isGroup" (click)="groupHeaderClick(row)"

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -124,7 +124,7 @@
             </td>
           </ng-container>
           <ng-container *ngIf="table.multiTemplateDataRows">
-            <td mat-cell *matCellDef="let row;let rowIndex =dataIndex " [ngClass]="[column.className, getCellAlignClass(column)]"
+            <td mat-cell *matCellDef="let row;let rowIndex = dataIndex " [ngClass]="[column.className, getCellAlignClass(column)]"
               (click)="handleClick(row,column, rowIndex, $event)" (dblclick)="handleDoubleClick(row,column, rowIndex, $event)"
               [class.empty-cell]="isEmpty(row[column.name])" [matTooltipDisabled]="!column.hasTooltip()" [matTooltip]="column.getTooltip(row)"
               matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
@@ -251,7 +251,7 @@
 
         <tr #tableHeader mat-header-row *matHeaderRowDef="oTableOptions.visibleColumns; sticky: fixedHeader"></tr>
 
-        <tr mat-row oTableRow *matRowDef="let row; columns: oTableOptions.visibleColumns;  when:isNotGroup; let i = index;let rowIndex = dataIndex;"
+        <tr mat-row oTableRow *matRowDef="let row; columns: oTableOptions.visibleColumns;  when:isNotGroup; let i = index"
           [class.selected]="isRowSelected(row)" [ngClass]="row | oTableRowClass: i: rowClass">
         </tr>
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -91,36 +91,70 @@
 
 
           <!--Define mat-cell-->
-          <td mat-cell *matCellDef="let row;let rowIndex = index" [ngClass]="[column.className, getCellAlignClass(column)]"
-            (click)="handleClick(row,column, rowIndex, $event)" (dblclick)="handleDoubleClick(row,column, rowIndex, $event)"
-            [class.empty-cell]="isEmpty(row[column.name])" [matTooltipDisabled]="!column.hasTooltip()" [matTooltip]="column.getTooltip(row)"
-            matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
-            [class.o-mat-cell-multiline]="(column.isMultiline | async)" [oContextMenu]="tableContextMenu"
-            [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}"
-            [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="getMinWidthColumn(column)"
-            [style.max-width]="column.maxWidth">
-            <div class="content">
+          <ng-container *ngIf="!table.multiTemplateDataRows">
+            <td mat-cell *matCellDef="let row;let rowIndex = index " [ngClass]="[column.className, getCellAlignClass(column)]"
+              (click)="handleClick(row,column, rowIndex, $event)" (dblclick)="handleDoubleClick(row,column, rowIndex, $event)"
+              [class.empty-cell]="isEmpty(row[column.name])" [matTooltipDisabled]="!column.hasTooltip()" [matTooltip]="column.getTooltip(row)"
+              matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
+              [class.o-mat-cell-multiline]="(column.isMultiline | async)" [oContextMenu]="tableContextMenu"
+              [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}"
+              [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="getMinWidthColumn(column)"
+              [style.max-width]="column.maxWidth">
+              <div class="content">
 
-              <ng-container [ngSwitch]="true">
-                <ng-container *ngSwitchCase="column.renderer != null && (!column.editing || column.editing && !selection.isSelected(row))">
-                  <ng-template *ngTemplateOutlet="column.renderer?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
-                  </ng-template>
-                </ng-container>
-                <ng-container *ngSwitchCase="selection.isSelected(row) && column.editing">
-                  <ng-template *ngTemplateOutlet="column.editor?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
-                  </ng-template>
+                <ng-container [ngSwitch]="true">
+                  <ng-container *ngSwitchCase="column.renderer != null && (!column.editing || column.editing && !selection.isSelected(row))">
+                    <ng-template *ngTemplateOutlet="column.renderer?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
+                    </ng-template>
+                  </ng-container>
+                  <ng-container *ngSwitchCase="selection.isSelected(row) && column.editing">
+                    <ng-template *ngTemplateOutlet="column.editor?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
+                    </ng-template>
+                  </ng-container>
+
+                  <ng-container *ngSwitchCase="column.type === 'editButtonInRow' || column.type === 'detailButtonInRow'">
+                    <div fxLayoutAlign="center center" class="o-action-cell-renderer" (click)="onDetailButtonClick(column, row, $event)">
+                      <mat-icon>{{ getDetailButtonIcon(column) }}</mat-icon>
+                    </div>
+                  </ng-container>
+                  <ng-container *ngSwitchDefault>{{ row[column.name] }}</ng-container>
                 </ng-container>
 
-                <ng-container *ngSwitchCase="column.type === 'editButtonInRow' || column.type === 'detailButtonInRow'">
-                  <div fxLayoutAlign="center center" class="o-action-cell-renderer" (click)="onDetailButtonClick(column, row, $event)">
-                    <mat-icon>{{ getDetailButtonIcon(column) }}</mat-icon>
-                  </div>
-                </ng-container>
-                <ng-container *ngSwitchDefault>{{ row[column.name] }}</ng-container>
-              </ng-container>
+              </div>
+            </td>
+          </ng-container>
+          <ng-container *ngIf="table.multiTemplateDataRows">
+            <td mat-cell *matCellDef="let row;let rowIndex =dataIndex " [ngClass]="[column.className, getCellAlignClass(column)]"
+              (click)="handleClick(row,column, rowIndex, $event)" (dblclick)="handleDoubleClick(row,column, rowIndex, $event)"
+              [class.empty-cell]="isEmpty(row[column.name])" [matTooltipDisabled]="!column.hasTooltip()" [matTooltip]="column.getTooltip(row)"
+              matTooltipPosition="below" matTooltipShowDelay="750" matTooltipClass="o-table-cell-tooltip"
+              [class.o-mat-cell-multiline]="(column.isMultiline | async)" [oContextMenu]="tableContextMenu"
+              [oContextMenuData]="{ cellName:column.name, rowValue:row, rowIndex:rowIndex}"
+              [style.width]="column.getRenderWidth(horizontalScroll, this.getClientWidthColumn(column))" [style.min-width]="getMinWidthColumn(column)"
+              [style.max-width]="column.maxWidth">
+              <div class="content">
 
-            </div>
-          </td>
+                <ng-container [ngSwitch]="true">
+                  <ng-container *ngSwitchCase="column.renderer != null && (!column.editing || column.editing && !selection.isSelected(row))">
+                    <ng-template *ngTemplateOutlet="column.renderer?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
+                    </ng-template>
+                  </ng-container>
+                  <ng-container *ngSwitchCase="selection.isSelected(row) && column.editing">
+                    <ng-template *ngTemplateOutlet="column.editor?.templateref; context:{ cellvalue: row[column.name], rowvalue:row }">
+                    </ng-template>
+                  </ng-container>
+
+                  <ng-container *ngSwitchCase="column.type === 'editButtonInRow' || column.type === 'detailButtonInRow'">
+                    <div fxLayoutAlign="center center" class="o-action-cell-renderer" (click)="onDetailButtonClick(column, row, $event)">
+                      <mat-icon>{{ getDetailButtonIcon(column) }}</mat-icon>
+                    </div>
+                  </ng-container>
+                  <ng-container *ngSwitchDefault>{{ row[column.name] }}</ng-container>
+                </ng-container>
+
+              </div>
+            </td>
+          </ng-container>
           <!--Define mat-footer-cell-->
           <ng-container *ngIf="showTotals | async">
             <td mat-footer-cell *matFooterCellDef [ngClass]="column.className">


### PR DESCRIPTION
Fixed reference **rowIndex** because when using the multiTemplateDataRows directive to support multiple rows for each data object, the context of *matRowDef is the same except that the index value is replaced by dataIndex and renderIndex.