### PR TITLE
[8.x.x] Issue 566

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.4
+### Bug Fixes
+* **oCurrency, oReal, oInteger, oPercent** pipes don't update the format of values when language is changed [a9343d0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/a9343d0)) Closes ([#566](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/566))
+
 ## 8.2.3 (2021-04-09)
 ### Features
 * **o-form**: new output `onCancel` [b1711d7e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b1711d7e))

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-currency.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-currency.pipe.ts
@@ -1,5 +1,4 @@
 import { Injector, Pipe, PipeTransform } from '@angular/core';
-
 import { CurrencyService } from '../services/currency.service';
 
 export interface ICurrencyPipeArgument {
@@ -13,11 +12,13 @@ export interface ICurrencyPipeArgument {
 }
 
 @Pipe({
-  name: 'oCurrency'
+  name: 'oCurrency',
+  pure: false
 })
 export class OCurrencyPipe implements PipeTransform {
 
   protected currencyService: CurrencyService;
+
   constructor(protected injector: Injector) {
     this.currencyService = this.injector.get(CurrencyService);
   }
@@ -25,4 +26,6 @@ export class OCurrencyPipe implements PipeTransform {
   transform(text: string, args: ICurrencyPipeArgument): string {
     return this.currencyService.getCurrencyValue(text, args);
   }
+
+
 }

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-currency.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-currency.pipe.ts
@@ -26,6 +26,4 @@ export class OCurrencyPipe implements PipeTransform {
   transform(text: string, args: ICurrencyPipeArgument): string {
     return this.currencyService.getCurrencyValue(text, args);
   }
-
-
 }

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-integer.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-integer.pipe.ts
@@ -9,7 +9,8 @@ export interface IIntegerPipeArgument {
 }
 
 @Pipe({
-  name: 'oInteger'
+  name: 'oInteger',
+  pure: false
 })
 
 export class OIntegerPipe implements PipeTransform {

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-integer.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-integer.pipe.ts
@@ -1,5 +1,4 @@
 import { Injector, Pipe, PipeTransform } from '@angular/core';
-
 import { NumberService } from '../services/number.service';
 
 export interface IIntegerPipeArgument {

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-percentage.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-percentage.pipe.ts
@@ -15,7 +15,8 @@ export interface IPercentPipeArgument {
 }
 
 @Pipe({
-  name: 'oPercent'
+  name: 'oPercent',
+  pure: false
 })
 export class OPercentPipe extends ORealPipe implements PipeTransform {
 
@@ -24,7 +25,9 @@ export class OPercentPipe extends ORealPipe implements PipeTransform {
   }
 
   transform(text: string, args: IPercentPipeArgument): string {
-    args.valueBase = this.parseValueBase(args.valueBase);
+    if (args && args.valueBase) {
+      args.valueBase = this.parseValueBase(args.valueBase);
+    }
     return this.numberService.getPercentValue(text, args);
   }
 

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-percentage.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-percentage.pipe.ts
@@ -1,5 +1,4 @@
 import { Injector, Pipe, PipeTransform } from '@angular/core';
-
 import { ORealPipe } from './o-real.pipe';
 
 export type OPercentageValueBaseType = 1 | 100;

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-real.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-real.pipe.ts
@@ -1,5 +1,4 @@
 import { Injector, Pipe, PipeTransform } from '@angular/core';
-
 import { OIntegerPipe } from './o-integer.pipe';
 
 export interface IRealPipeArgument {

--- a/projects/ontimize-web-ngx/src/lib/pipes/o-real.pipe.ts
+++ b/projects/ontimize-web-ngx/src/lib/pipes/o-real.pipe.ts
@@ -12,7 +12,8 @@ export interface IRealPipeArgument {
 }
 
 @Pipe({
-  name: 'oReal'
+  name: 'oReal',
+  pure: false
 })
 export class ORealPipe extends OIntegerPipe implements PipeTransform {
 

--- a/projects/ontimize-web-ngx/src/lib/services/number.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/number.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Injector } from '@angular/core';
-
-import { AppConfig } from '../config/app-config';
-import { Config } from '../types/config.type';
 import { Util } from '../util/util';
+import { OTranslateService } from './translate/o-translate.service';
 
 @Injectable({
   providedIn: 'root'
@@ -15,16 +13,25 @@ export class NumberService {
   protected _minDecimalDigits: number;
   protected _maxDecimalDigits: number;
   protected _locale: string;
-  private _config: Config;
+
+  protected translateService: OTranslateService;
 
   constructor(protected injector: Injector) {
-    this._config = this.injector.get(AppConfig).getConfiguration();
+
+
+    this.translateService = this.injector.get(OTranslateService);
     // TODO: initialize from config
     this._minDecimalDigits = NumberService.DEFAULT_DECIMAL_DIGITS;
     this._maxDecimalDigits = NumberService.DEFAULT_DECIMAL_DIGITS;
 
     this._grouping = true;
-    this._locale = this._config.locale;
+
+    const self = this;
+    this._locale = this.translateService.getCurrentLang()
+    this.translateService.onLanguageChanged.subscribe(() =>
+      self._locale = self.translateService.getCurrentLang()
+
+    );
   }
 
   get grouping(): boolean {
@@ -61,7 +68,7 @@ export class NumberService {
 
   getIntegerValue(value: any, args: any) {
     const grouping = args ? args.grouping : undefined;
-    if (!Util.isDefined(value) && !Util.isDefined(grouping) || !grouping) {
+    if (!Util.isDefined(value)) {
       return value;
     }
     const thousandSeparator = args ? args.thousandSeparator : undefined;
@@ -84,10 +91,11 @@ export class NumberService {
   }
 
   getRealValue(value: any, args: any) {
-    const grouping = args ? args.grouping : undefined;
-    if (!Util.isDefined(value) && !Util.isDefined(grouping) || !grouping) {
+    const grouping = args ? args.grouping : false;
+    if (!Util.isDefined(value)) {
       return value;
     }
+
     const locale = args ? args.locale : undefined;
     const thousandSeparator = args ? args.thousandSeparator : undefined;
     const decimalSeparator = args ? args.decimalSeparator : undefined;
@@ -108,7 +116,8 @@ export class NumberService {
       minimumFractionDigits: minDecimalDigits,
       maximumFractionDigits: maxDecimalDigits,
       minimumSignificantDigits: significantDigits,
-      maximumSignificantDigits: significantDigits
+      maximumSignificantDigits: significantDigits,
+      useGrouping: grouping
     };
 
     if (Util.isDefined(locale)) {

--- a/projects/ontimize-web-ngx/src/lib/services/number.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/number.service.ts
@@ -18,7 +18,6 @@ export class NumberService {
 
   constructor(protected injector: Injector) {
 
-
     this.translateService = this.injector.get(OTranslateService);
     // TODO: initialize from config
     this._minDecimalDigits = NumberService.DEFAULT_DECIMAL_DIGITS;
@@ -30,7 +29,6 @@ export class NumberService {
     this._locale = this.translateService.getCurrentLang()
     this.translateService.onLanguageChanged.subscribe(() =>
       self._locale = self.translateService.getCurrentLang()
-
     );
   }
 


### PR DESCRIPTION
- Set pipes as impure
- Added useGrouping in the options  of Intl.NumberFormat
- Closes #566