### PR TITLE
Refactor authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.2.3
+## 8.2.3 (2021-04-09)
 ### Features
 * **o-form**: new output `onCancel` [b1711d7e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b1711d7e))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 8.3.0
+### BREAKING CHANGES
+* Authentication has been refactored:
+  * Service `LoginService` has been removed and replaced by `AuthService`. This is an abstract service that provides basic functionality regarding authentication. Its default implementation is `OntimizeAuthService` class that performs authentication with Ontimize based backends. Developers can provide their own implementation using the Injection Token `O_AUTH_SERVICE` and the class of their service that extends `AuthService` class.
+  * Method `redirectLogin` has been removed in class `OntimizeBaseService` and all its subclasses (`OntimizeService`, `OntimizeEEService`, `OntimizeExportService` and `OntimizeFileService`), use method `logout` from `AuthService` instead.
+  * Method `redirectLogin` has been removed in class `ServiceUtils`, now it is a method of Ontimize authentication implementation in `OntimizeAuthService`.
+
 ## 8.2.3 (2021-04-09)
 ### Features
 * **o-form**: new output `onCancel` [b1711d7e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b1711d7e))
@@ -57,8 +64,8 @@
   * method `handleCellClick` has been removed, you have to use `handleClick` instead  ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
   * method `handleCellDoubleClick` has been removed, you have to use `handleDoubleClick` instead ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
   * Changed the parametres of the `handleDoubleClick` and `handleCellClick` methods ([e64dcc3](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e64dcc3)) ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
-## 8.1.1 (2020-11-25)
 
+## 8.1.1 (2020-11-25)
 ### Bug Fixes
 * **table**: fixing bug in filtering by column ([88ac4bf](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/88ac4bf))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### BREAKING CHANGES
 * Authentication has been refactored:
   * Service `LoginService` has been removed and replaced by `AuthService`. This is an abstract service that provides basic functionality regarding authentication. Its default implementation is `OntimizeAuthService` class that performs authentication with Ontimize based backends. Developers can provide their own implementation using the Injection Token `O_AUTH_SERVICE` and the class of their service that extends `AuthService` class.
+  * Interface `ILoginService` has been removed, use abstract class `AuthService` instead.
   * Method `redirectLogin` has been removed in class `OntimizeBaseService` and all its subclasses (`OntimizeService`, `OntimizeEEService`, `OntimizeExportService` and `OntimizeFileService`), use method `logout` from `AuthService` instead.
   * Method `redirectLogin` has been removed in class `ServiceUtils`, now it is a method of Ontimize authentication implementation in `OntimizeAuthService`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,20 +61,10 @@
 * **o-table, OBaseTableCellEditor**: Ignoring keyboard events from outside a cell being edited. Also stopping active cell edition when table content has changed ([d888fad](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/d888fad)) Closes ([#523](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/523))
 
 ### BREAKING CHANGES
-<<<<<<< HEAD
 * **table**:
   * method `handleCellClick` has been removed, you have to use `handleClick` instead  ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
   * method `handleCellDoubleClick` has been removed, you have to use `handleDoubleClick` instead ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
   * Changed the parametres of the `handleDoubleClick` and `handleCellClick` methods ([e64dcc3](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e64dcc3)) ([0cc55af](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0cc55af))
-=======
-* Authentication has been refactored:
-  * Service `LoginService` has been removed and replaced by `AuthService`. This is an abstract service that provides basic functionality regarding authentication. Its default implementation is `OntimizeAuthService` class that performs authentication with Ontimize based backends. Developers can provide their own implementation using the Injection Token `O_AUTH_SERVICE` and the class of their service that extends `AuthService` class.
-  * Interface `ILoginService` has been removed, use abstract class `AuthService` instead.
-  * Method `redirectLogin` has been removed in class `OntimizeBaseService` and all its subclasses (`OntimizeService`, `OntimizeEEService`, `OntimizeExportService` and `OntimizeFileService`), use method `logout` from `AuthService` instead.
-  * Method `redirectLogin` has been removed in class `ServiceUtils`, now it is a method of Ontimize authentication implementation in `OntimizeAuthService`.
-
-## 8.1.1 (2020-11-25)
->>>>>>> c4a48cccfe43711c486c7a206661d850c8647920
 
 ## 8.1.1 (2020-11-25)
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontimize-web-ngx",
-  "version": "8.2.3",
+  "version": "8.3.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ontimize-web-ngx/package.json
+++ b/projects/ontimize-web-ngx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontimize-web-ngx",
   "homepage": "https://github.com/OntimizeWeb/ontimize-web-ngx#readme",
-  "version": "8.2.3",
+  "version": "8.3.0",
   "description": "Ontimize Web framework using Angular 8",
   "bugs": "https://github.com/OntimizeWeb/ontimize-web-ngx/issues",
   "author": "Imatia S.L.",

--- a/projects/ontimize-web-ngx/src/lib/components/app-header/o-app-header.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/app-header/o-app-header.component.ts
@@ -1,13 +1,12 @@
-import { ViewChild } from '@angular/core';
-import { Component, ElementRef, EventEmitter, Injector, OnDestroy, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Injector, OnDestroy, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ThemePalette } from '@angular/material';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { InputConverter } from '../../decorators/input-converter';
+import { AuthService } from '../../services';
 import { DialogService } from '../../services/dialog.service';
 import { OModulesInfoService } from '../../services/o-modules-info.service';
-import { ServiceUtils } from '../../util/service.utils';
 import { OUserInfoComponent } from '../user-info/o-user-info.component';
 
 export const DEFAULT_INPUTS_O_APP_HEADER = [
@@ -36,6 +35,7 @@ export class OAppHeaderComponent implements OnDestroy {
 
   protected dialogService: DialogService;
   protected modulesInfoService: OModulesInfoService;
+  protected authService: AuthService;
   protected _headerTitle = '';
 
   protected modulesInfoSubscription: Subscription;
@@ -61,6 +61,7 @@ export class OAppHeaderComponent implements OnDestroy {
   ) {
     this.dialogService = this.injector.get(DialogService);
     this.modulesInfoService = this.injector.get(OModulesInfoService);
+    this.authService = this.injector.get(AuthService);
 
     this.modulesInfoSubscription = this.modulesInfoService.getModuleChangeObservable().subscribe(res => {
       this.headerTitle = res.name;
@@ -72,11 +73,7 @@ export class OAppHeaderComponent implements OnDestroy {
   }
 
   onLogoutClick() {
-    this.dialogService.confirm('CONFIRM', 'MESSAGES.CONFIRM_LOGOUT').then(res => {
-      if (res) {
-        ServiceUtils.redirectLogin(this.router, false);
-      }
-    });
+    this.authService.logoutWithConfirmation();
   }
 
   get headerTitle(): string {

--- a/projects/ontimize-web-ngx/src/lib/components/app-sidenav/menu-item/o-app-sidenav-menu-item.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/app-sidenav/menu-item/o-app-sidenav-menu-item.component.ts
@@ -8,22 +8,16 @@ import {
   Injector,
   OnDestroy,
   OnInit,
-  ViewEncapsulation,
+  ViewEncapsulation
 } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 
 import { InputConverter } from '../../../decorators/input-converter';
-import {
-  MenuItemAction,
-  MenuItemLocale,
-  MenuItemLogout,
-  MenuItemRoute,
-  MenuItemUserInfo,
-} from '../../../interfaces/app-menu.interface';
+import { MenuItemAction, MenuItemLocale, MenuItemLogout, MenuItemRoute, MenuItemUserInfo } from '../../../interfaces/app-menu.interface';
 import { OAppLayoutComponent } from '../../../layouts/app-layout/o-app-layout.component';
+import { AuthService } from '../../../services/auth.service';
 import { DialogService } from '../../../services/dialog.service';
-import { LoginService } from '../../../services/login.service';
 import { OUserInfoService } from '../../../services/o-user-info.service';
 import { PermissionsService } from '../../../services/permissions/permissions.service';
 import { OTranslateService } from '../../../services/translate/o-translate.service';
@@ -61,7 +55,7 @@ export class OAppSidenavMenuItemComponent implements OnInit, AfterViewInit, OnDe
   public onClick: EventEmitter<any> = new EventEmitter<any>();
 
   protected translateService: OTranslateService;
-  protected loginService: LoginService;
+  protected authService: AuthService;
   protected dialogService: DialogService;
   protected permissionsService: PermissionsService;
   protected oUserInfoService: OUserInfoService;
@@ -91,7 +85,7 @@ export class OAppSidenavMenuItemComponent implements OnInit, AfterViewInit, OnDe
     protected cd: ChangeDetectorRef
   ) {
     this.translateService = this.injector.get(OTranslateService);
-    this.loginService = this.injector.get(LoginService);
+    this.authService = this.injector.get(AuthService);
     this.dialogService = this.injector.get(DialogService);
     this.permissionsService = this.injector.get(PermissionsService);
     this.oUserInfoService = this.injector.get(OUserInfoService);
@@ -198,9 +192,9 @@ export class OAppSidenavMenuItemComponent implements OnInit, AfterViewInit, OnDe
   logout() {
     const menuItem = (this.menuItem as MenuItemLogout);
     if (Util.parseBoolean(menuItem.confirm, true)) {
-      this.loginService.logoutWithConfirmationAndRedirect();
+      this.authService.logoutWithConfirmation();
     } else {
-      this.loginService.logoutAndRedirect();
+      this.authService.logout();
     }
   }
 

--- a/projects/ontimize-web-ngx/src/lib/components/user-info/o-user-info.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/user-info/o-user-info.component.ts
@@ -1,10 +1,10 @@
 import { Component, ElementRef, Injector, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { Router } from '@angular/router';
 import { Subscription } from 'rxjs';
-import { InputConverter } from '../../decorators';
 
+import { InputConverter } from '../../decorators';
+import { AuthService } from '../../services/auth.service';
 import { DialogService } from '../../services/dialog.service';
-import { LoginService } from '../../services/login.service';
 import { OUserInfoService, UserInfo } from '../../services/o-user-info.service';
 import { OUserInfoConfigurationDirective } from './user-info-configuration/o-user-info-configuration.directive';
 
@@ -30,7 +30,7 @@ export const DEFAULT_OUTPUTS_O_USER_INFO = [];
 export class OUserInfoComponent implements OnDestroy {
 
   protected dialogService: DialogService;
-  protected loginService: LoginService;
+  protected authService: AuthService;
   protected oUserInfoService: OUserInfoService;
 
   userInfoSubscription: Subscription;
@@ -53,14 +53,13 @@ export class OUserInfoComponent implements OnDestroy {
     protected router: Router
   ) {
     this.dialogService = this.injector.get(DialogService);
-    this.loginService = this.injector.get(LoginService);
+    this.authService = this.injector.get(AuthService);
     this.oUserInfoService = this.injector.get(OUserInfoService);
 
     this.userInfo = this.oUserInfoService.getUserInfo();
     this.userInfoSubscription = this.oUserInfoService.getUserInfoObservable().subscribe(res => {
       this.userInfo = res;
     });
-
   }
 
   ngOnDestroy() {
@@ -68,7 +67,7 @@ export class OUserInfoComponent implements OnDestroy {
   }
 
   onLogoutClick() {
-    this.loginService.logoutWithConfirmationAndRedirect();
+    this.authService.logoutWithConfirmation();
   }
 
   onSettingsClick() {
@@ -97,9 +96,9 @@ export class OUserInfoComponent implements OnDestroy {
   }
 
   private updateInputsByConfiguration() {
-    this.showLogout = this.userInfoConfiguration.showLogout ? this.userInfoConfiguration.showLogout : this.showLogout;
-    this.showProfile = this.userInfoConfiguration.showProfile ? this.userInfoConfiguration.showProfile : this.showProfile;
-    this.showSettings = this.userInfoConfiguration.showSettings ? this.userInfoConfiguration.showSettings : this.showSettings;
+    this.showLogout = this.userInfoConfiguration ? this.userInfoConfiguration.showLogout : this.showLogout;
+    this.showProfile = this.userInfoConfiguration ? this.userInfoConfiguration.showProfile : this.showProfile;
+    this.showSettings = this.userInfoConfiguration ? this.userInfoConfiguration.showSettings : this.showSettings;
   }
 
 }

--- a/projects/ontimize-web-ngx/src/lib/config/o-providers.ts
+++ b/projects/ontimize-web-ngx/src/lib/config/o-providers.ts
@@ -6,7 +6,7 @@ import { combineLatest } from 'rxjs';
 
 import { AppConfig, O_INPUTS_OPTIONS } from '../config/app-config';
 import { appConfigFactory } from '../services/app-config.provider';
-import { OntimizeServiceProvider } from '../services/factories';
+import { OntimizeAuthServiceProvider, OntimizeServiceProvider } from '../services/factories';
 import { LocalStorageService } from '../services/local-storage.service';
 import { NavigationService } from '../services/navigation.service';
 import { OntimizeMatIconRegistry } from '../services/ontimize-icon-registry.service';
@@ -79,6 +79,7 @@ export const ONTIMIZE_PROVIDERS: Provider[] = [
   { provide: AppConfig, useFactory: appConfigFactory, deps: [Injector] },
   OntimizeServiceProvider,
   OntimizeServiceResponseAdapter,
+  OntimizeAuthServiceProvider,
   // disabled global ripple
   { provide: MAT_RIPPLE_GLOBAL_OPTIONS, useValue: { disabled: true } },
   { provide: O_MAT_ERROR_OPTIONS, useValue: {} },

--- a/projects/ontimize-web-ngx/src/lib/interfaces/auth-service.interface.ts
+++ b/projects/ontimize-web-ngx/src/lib/interfaces/auth-service.interface.ts
@@ -4,5 +4,4 @@ export interface IAuthService {
   startsession(user: string, password: string): Observable<string | number>;
   endsession(user: string, sessionId: string | number): Observable<number>;
   hassession(user: string, sessionId: string | number): Observable<boolean>;
-  redirectLogin?(sessionExpired?: boolean);
 }

--- a/projects/ontimize-web-ngx/src/lib/interfaces/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/interfaces/index.ts
@@ -9,7 +9,6 @@ export * from './form-control-component.interface';
 export * from './form-data-component.interface';
 export * from './form-data-type-component.interface';
 export * from './local-storage-component.interface';
-export * from './login-service.interface';
 export * from './multiple-selection.interface';
 export * from './o-context-menu.interface';
 export * from './o-form-layout-tab-group.interface';

--- a/projects/ontimize-web-ngx/src/lib/interfaces/login-service.interface.ts
+++ b/projects/ontimize-web-ngx/src/lib/interfaces/login-service.interface.ts
@@ -1,8 +1,0 @@
-import { Observable } from 'rxjs';
-
-export interface ILoginService {
-  login(user: string, password: string): Observable<any>;
-  logout(): void;
-  sessionExpired(): void;
-  isLoggedIn(): boolean;
-}

--- a/projects/ontimize-web-ngx/src/lib/services/auth-guard.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/auth-guard.service.ts
@@ -3,7 +3,7 @@ import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from
 
 import { OUserInfoService } from '../services/o-user-info.service';
 import { Codes } from '../util/codes';
-import { LoginStorageService } from './login-storage.service';
+import { AuthService } from './auth.service';
 import { PermissionsService } from './permissions/permissions.service';
 
 @Injectable({
@@ -12,19 +12,19 @@ import { PermissionsService } from './permissions/permissions.service';
 export class AuthGuardService implements CanActivate {
 
   protected router: Router;
-  protected loginStorageService: LoginStorageService;
+  protected authService: AuthService;
   protected oUserInfoService: OUserInfoService;
   protected permissionsService: PermissionsService;
 
   constructor(protected injector: Injector) {
     this.router = this.injector.get(Router);
-    this.loginStorageService = this.injector.get(LoginStorageService);
+    this.authService = this.injector.get(AuthService);
     this.oUserInfoService = this.injector.get(OUserInfoService);
     this.permissionsService = this.injector.get(PermissionsService);
   }
 
   canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> | boolean {
-    const isLoggedIn = this.loginStorageService.isLoggedIn();
+    const isLoggedIn = this.authService.isLoggedIn();
     let result: Promise<boolean> | boolean = isLoggedIn;
     if (!isLoggedIn) {
       this.permissionsService.restart();
@@ -40,11 +40,12 @@ export class AuthGuardService implements CanActivate {
   }
 
   setUserInformation() {
-    const sessionInfo = this.loginStorageService.getSessionInfo();
+    const sessionInfo = this.authService.getSessionInfo();
     // TODO query user information
     this.oUserInfoService.setUserInfo({
       username: sessionInfo.user,
       avatar: './assets/images/user_profile.png'
     });
   }
+
 }

--- a/projects/ontimize-web-ngx/src/lib/services/auth.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/auth.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, Injector } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
+
+import { SessionInfo } from '../types';
+import { DialogService } from './dialog.service';
+
+@Injectable()
+export abstract class AuthService {
+
+  public onLogin: Subject<any> = new Subject();
+  public onLogout: Subject<any> = new Subject();
+
+  protected dialogService: DialogService;
+
+  constructor(protected injector: Injector) {
+    this.dialogService = injector.get(DialogService);
+  }
+
+  public abstract login(user: string, password: string): Observable<any>;
+  public abstract logout(): Observable<any>;
+  public abstract clearSessionData(): void;
+  public abstract isLoggedIn(): boolean;
+  public abstract getSessionInfo(): SessionInfo;
+
+  public logoutWithConfirmation(): void {
+    this.dialogService.confirm('CONFIRM', 'MESSAGES.CONFIRM_LOGOUT').then(res => {
+      if (res) {
+        this.logout();
+      }
+    });
+  }
+
+}

--- a/projects/ontimize-web-ngx/src/lib/services/base-service.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/base-service.class.ts
@@ -11,8 +11,8 @@ import { HttpRequestOptions } from '../types';
 import { Config } from '../types/config.type';
 import { ServiceRequestParam } from '../types/service-request-param.type';
 import { Codes } from '../util/codes';
+import { AuthService } from './auth.service';
 import { BaseServiceResponse } from './base-service-response.class';
-import { LoginStorageService } from './login-storage.service';
 import { OntimizeServiceResponseAdapter } from './ontimize/ontimize-service-response.adapter';
 import { OntimizeServiceResponseParser } from './parser/o-service-response.parser';
 
@@ -25,7 +25,7 @@ export class BaseService {
   protected _appConfig: Config;
   protected _config: AppConfig;
   protected responseParser: OntimizeServiceResponseParser;
-  protected loginStorageService: LoginStorageService;
+  protected authService: AuthService;
   protected adapter: ServiceResponseAdapter<BaseServiceResponse>;
 
   constructor(protected injector: Injector) {
@@ -34,7 +34,7 @@ export class BaseService {
     this._config = this.injector.get(AppConfig);
     this._appConfig = this._config.getConfiguration();
     this.responseParser = this.injector.get(OntimizeServiceResponseParser);
-    this.loginStorageService = this.injector.get(LoginStorageService);
+    this.authService = this.injector.get(AuthService);
     this.configureAdapter();
   }
 
@@ -52,7 +52,7 @@ export class BaseService {
     if (serviceName && configuration.hasOwnProperty(serviceName)) {
       servConfig = configuration[serviceName];
     }
-    servConfig[Codes.SESSION_KEY] = this.loginStorageService.getSessionInfo();
+    servConfig[Codes.SESSION_KEY] = this.authService.getSessionInfo();
     return servConfig;
   }
 

--- a/projects/ontimize-web-ngx/src/lib/services/factories.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/factories.ts
@@ -5,6 +5,8 @@ import { IExportService } from '../interfaces/export-service.interface';
 import { IFileService } from '../interfaces/file-service.interface';
 import { IPermissionsService } from '../interfaces/permissions-service.interface';
 import { Util } from '../util/util';
+import { AuthService } from './auth.service';
+import { OntimizeAuthService } from './o-auth.service';
 import { OntimizeEEService } from './ontimize/ontimize-ee.service';
 import { OntimizeExportService } from './ontimize/ontimize-export.service';
 import { OntimizeFileService } from './ontimize/ontimize-file.service';
@@ -40,6 +42,11 @@ export const O_EXPORT_SERVICE = new InjectionToken<IExportService>('Export servi
  * Injection token that can be used to replace the permission service `OntimizePermissionsService or OntimizeEEPermissionsService`.
  */
 export const O_PERMISSION_SERVICE = new InjectionToken<IPermissionsService>('Permission service');
+
+/**
+ * Injection token that can be used to replace the authentication service `AuthService`.
+ */
+export const O_AUTH_SERVICE = new InjectionToken<AuthService>('Authentication service');
 
 /* ----------------------------------------------------------------------------------------------------
  * --------------------------------------------- FACTORIES --------------------------------------------
@@ -106,6 +113,15 @@ export function permissionsServiceFactory(injector: Injector): IPermissionsServi
   return _createServiceInstance(config.permissionsServiceType, injector);
 }
 
+/**
+ * Creates a new instance of the authentication service.
+ */
+export function authServiceFactory(injector: Injector): AuthService {
+  const serviceClass = _getInjectionTokenValue(O_AUTH_SERVICE, injector);
+  const service = _createServiceInstance(serviceClass, injector);
+  return Util.isDefined(service) ? service : new OntimizeAuthService(injector);
+}
+
 /* ----------------------------------------------------------------------------------------------------
  * -------------------------------------------- PROVIDERS ---------------------------------------------
  * ----------------------------------------------------------------------------------------------------
@@ -116,6 +132,8 @@ export function permissionsServiceFactory(injector: Injector): IPermissionsServi
 export let OntimizeServiceProvider = { provide: OntimizeService, useFactory: dataServiceFactory, deps: [Injector] };
 
 export let OntimizeExportServiceProvider = { provide: OntimizeExportService, useFactory: exportServiceFactory, deps: [Injector] };
+
+export const OntimizeAuthServiceProvider = { provide: AuthService, useFactory: authServiceFactory, deps: [Injector] };
 
 /* ----------------------------------------------------------------------------------------------------
  * ----------------------------------------- Utility methods ------------------------------------------

--- a/projects/ontimize-web-ngx/src/lib/services/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/index.ts
@@ -8,7 +8,7 @@ export * from './dialog.service';
 export * from './factories';
 export * from './local-storage.service';
 export * from './login-storage.service';
-export * from './login.service';
+export * from './auth.service';
 export * from './moment.service';
 export * from './navigation.service';
 export * from './number.service';

--- a/projects/ontimize-web-ngx/src/lib/services/local-storage.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/local-storage.service.ts
@@ -7,7 +7,7 @@ import { Config } from '../types/config.type';
 import { SessionInfo } from '../types/session-info.type';
 import { ObservableWrapper } from '../util/async';
 import { Util } from '../util/util';
-import { LoginStorageService } from './login-storage.service';
+import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,12 +22,12 @@ export class LocalStorageService {
 
   private _config: Config;
   private _router: Router;
-  private loginStorageService: LoginStorageService;
+  private authService: AuthService;
 
   constructor(protected injector: Injector) {
     this._config = this.injector.get(AppConfig).getConfiguration();
     this._router = this.injector.get(Router);
-    this.loginStorageService = this.injector.get(LoginStorageService);
+    this.authService = this.injector.get(AuthService);
 
     const self = this;
     this._router.events.subscribe(event => {
@@ -117,7 +117,7 @@ export class LocalStorageService {
       return;
     }
     const users = appData[LocalStorageService.USERS_STORAGE_KEY] || {}; // uuid -> users
-    const idUser = session.user || this.loginStorageService.getSessionInfo().user;
+    const idUser = session.user || this.authService.getSessionInfo().user;
     const user = users[idUser] || {}; // uuid -> users-> user
 
     let componentData = {};
@@ -173,5 +173,5 @@ export class LocalStorageService {
     this.onSetLocalStorage.emit();
     localStorage.setItem(this._config.uuid, JSON.stringify(appData));
   }
-}
 
+}

--- a/projects/ontimize-web-ngx/src/lib/services/login-storage.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/login-storage.service.ts
@@ -5,10 +5,9 @@ import { Config } from '../types/config.type';
 import { SessionInfo } from '../types/session-info.type';
 import { Codes } from '../util/codes';
 
-@Injectable({
-  providedIn: 'root'
-})
+@Injectable({ providedIn: 'root' })
 export class LoginStorageService {
+
   private _config: Config;
   public _localStorageKey: string;
 
@@ -57,4 +56,5 @@ export class LoginStorageService {
     }
     return false;
   }
+
 }

--- a/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-base-service.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-base-service.class.ts
@@ -2,12 +2,10 @@ import { Injector } from '@angular/core';
 import { Observable } from 'rxjs';
 
 import { IAuthService } from '../../interfaces/auth-service.interface';
-import { ServiceUtils } from '../../util/service.utils';
 import { BaseService } from '../base-service.class';
 
 export class OntimizeBaseService extends BaseService implements IAuthService {
 
-  protected _sessionid: string;
   protected _startSessionPath: string;
 
   public kv = {};
@@ -24,7 +22,6 @@ export class OntimizeBaseService extends BaseService implements IAuthService {
 
   public configureService(config: any): void {
     super.configureService(config);
-    this._sessionid = config.session ? config.session.id : -1;
   }
 
   public startsession(user: string, password: string): Observable<any> {
@@ -39,16 +36,10 @@ export class OntimizeBaseService extends BaseService implements IAuthService {
     return null;
   }
 
-  public redirectLogin(sessionExpired: boolean = false) {
-    if (sessionExpired) {
-      this.loginStorageService.sessionExpired();
-    }
-    ServiceUtils.redirectLogin(this.router, sessionExpired);
-  }
-
   public clientErrorFallback(errorCode: number) {
     if (errorCode === 401) {
-      this.redirectLogin(true);
+      this.authService.logout();
     }
   }
+
 }

--- a/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-ee.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-ee.service.ts
@@ -167,8 +167,12 @@ export class OntimizeEEService extends OntimizeBaseService implements IDataServi
   }
 
   protected buildHeaders(): HttpHeaders {
-    const headers = super.buildHeaders();
-    return headers.append('Authorization', 'Bearer ' + this._sessionid);
+    let headers = super.buildHeaders();
+    const sessionId = this.authService.getSessionInfo().id;
+    if (Util.isDefined(sessionId)) {
+      headers = headers.append('Authorization', 'Bearer ' + sessionId);
+    }
+    return headers;
   }
 
 }

--- a/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-export.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-export.service.ts
@@ -6,6 +6,7 @@ import { map, share } from 'rxjs/operators';
 import { IExportService } from '../../interfaces/export-service.interface';
 import { ServiceResponse } from '../../interfaces/service-response.interface';
 import { HttpRequestOptions } from '../../types';
+import { Util } from '../../util';
 import { OntimizeBaseService } from './ontimize-base-service.class';
 
 @Injectable()
@@ -15,7 +16,6 @@ export class OntimizeExportService extends OntimizeBaseService implements IExpor
   public downloadPath: string;
   public servicePath: string;
 
-  protected _sessionid: string;
   protected exportAll: boolean = false;
 
   constructor(protected injector: Injector) {
@@ -37,10 +37,12 @@ export class OntimizeExportService extends OntimizeBaseService implements IExpor
   }
 
   protected buildHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      'Access-Control-Allow-Origin': '*',
-      Authorization: 'Bearer ' + this._sessionid
-    });
+    let headers = new HttpHeaders({ 'Access-Control-Allow-Origin': '*' });
+    const sessionId = this.authService.getSessionInfo().id;
+    if (Util.isDefined(sessionId)) {
+      headers = headers.append('Authorization', 'Bearer ' + sessionId);
+    }
+    return headers;
   }
 
   public exportData(data: any, format: string, entity?: string): Observable<any> {

--- a/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-file.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize-file.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { share } from 'rxjs/operators';
 
 import { IFileService } from '../../interfaces/file-service.interface';
+import { Util } from '../../util';
 import { OntimizeBaseService } from './ontimize-base-service.class';
 
 @Injectable()
@@ -57,7 +58,7 @@ export class OntimizeFileService extends OntimizeBaseService implements IFileSer
           // Full response received
           if (resp.body) {
             if (resp.body['code'] === 3) {
-              this.redirectLogin(true);
+              this.authService.logout();
             } else if (resp.body['code'] === 1) {
               observer.error(resp.body['message']);
             } else if (resp.body['code'] === 0) {
@@ -74,7 +75,7 @@ export class OntimizeFileService extends OntimizeBaseService implements IFileSer
       }, error => {
         console.error(error);
         if (error.status === 401) {
-          this.redirectLogin(true);
+          this.authService.logout();
         } else {
           observer.error(error);
         }
@@ -85,11 +86,12 @@ export class OntimizeFileService extends OntimizeBaseService implements IFileSer
   }
 
   protected buildHeaders(): HttpHeaders {
-    return new HttpHeaders({
-      'Access-Control-Allow-Origin': '*',
-      Authorization: 'Bearer ' + this._sessionid
-    });
+    let headers = new HttpHeaders({ 'Access-Control-Allow-Origin': '*' });
+    const sessionId = this.authService.getSessionInfo().id;
+    if (Util.isDefined(sessionId)) {
+      headers = headers.append('Authorization', 'Bearer ' + sessionId);
+    }
+    return headers;
   }
-
 
 }

--- a/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/ontimize/ontimize.service.ts
@@ -76,7 +76,7 @@ export class OntimizeService extends OntimizeBaseService implements IDataService
 
     const body = JSON.stringify({
       user: this.user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       type: 1,
       entity: entity,
       kv: kv,
@@ -109,7 +109,7 @@ export class OntimizeService extends OntimizeBaseService implements IDataService
 
     const body = JSON.stringify({
       user: this.user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       type: 1,
       entity: entity,
       kv: kv,
@@ -138,7 +138,7 @@ export class OntimizeService extends OntimizeBaseService implements IDataService
 
     const body = JSON.stringify({
       user: this.user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       entity: entity,
       av: av,
       sqltypes: sqltypes
@@ -164,7 +164,7 @@ export class OntimizeService extends OntimizeBaseService implements IDataService
 
     const body = JSON.stringify({
       user: this.user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       entity: entity,
       kv: kv,
       av: av,
@@ -189,7 +189,7 @@ export class OntimizeService extends OntimizeBaseService implements IDataService
 
     const body = JSON.stringify({
       user: this.user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       entity: entity,
       kv: kv,
       sqltypes: sqltypes

--- a/projects/ontimize-web-ngx/src/lib/services/permissions/ontimize-permissions.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/permissions/ontimize-permissions.service.ts
@@ -9,7 +9,7 @@ import { Config } from '../../types/config.type';
 import { OntimizePermissionsConfig } from '../../types/ontimize-permissions-config.type';
 import { Codes } from '../../util/codes';
 import { Util } from '../../util/util';
-import { LoginStorageService } from '../login-storage.service';
+import { AuthService } from '../auth.service';
 
 @Injectable()
 export class OntimizePermissionsService implements IPermissionsService {
@@ -19,29 +19,30 @@ export class OntimizePermissionsService implements IPermissionsService {
   public valueColumn: string;
 
   protected httpClient: HttpClient;
-  protected _sessionid: number = -1;
   protected _user: string;
   protected _urlBase: string;
   protected _appConfig: Config;
   protected _config: AppConfig;
 
+  protected authService: AuthService;
+
   constructor(protected injector: Injector) {
     this.httpClient = this.injector.get(HttpClient);
     this._config = this.injector.get(AppConfig);
     this._appConfig = this._config.getConfiguration();
+    this.authService = this.injector.get(AuthService);
   }
 
   getDefaultServiceConfiguration(): any {
-    const loginStorageService = this.injector.get(LoginStorageService);
+    const authService = this.injector.get(AuthService);
     const servConfig = {};
-    servConfig[Codes.SESSION_KEY] = loginStorageService.getSessionInfo();
+    servConfig[Codes.SESSION_KEY] = authService.getSessionInfo();
     return servConfig;
   }
 
   configureService(permissionsConfig: OntimizePermissionsConfig): void {
     const config = this.getDefaultServiceConfiguration();
     this._urlBase = config.urlBase ? config.urlBase : this._appConfig.apiEndpoint;
-    this._sessionid = config.session ? config.session.id : -1;
     this._user = config.session ? config.session.user : '';
 
     if (Util.isDefined(permissionsConfig)) {
@@ -69,7 +70,7 @@ export class OntimizePermissionsService implements IPermissionsService {
     };
     const body = JSON.stringify({
       user: this._user,
-      sessionid: this._sessionid,
+      sessionid: this.authService.getSessionInfo().id,
       type: 1,
       entity: this.entity,
       kv: kv,
@@ -104,4 +105,5 @@ export class OntimizePermissionsService implements IPermissionsService {
       'Content-Type': 'application/json;charset=UTF-8'
     });
   }
+
 }

--- a/projects/ontimize-web-ngx/src/lib/services/remote-config.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/remote-config.service.ts
@@ -8,8 +8,8 @@ import { ORemoteConfiguration, ORemoteConfigurationColumns } from '../types/remo
 import { SessionInfo } from '../types/session-info.type';
 import { Codes } from '../util/codes';
 import { Util } from '../util/util';
+import { AuthService } from './auth.service';
 import { LocalStorageService } from './local-storage.service';
-import { LoginStorageService } from './login-storage.service';
 
 @Injectable({
   providedIn: 'root'
@@ -22,7 +22,7 @@ export class ORemoteConfigurationService {
   public static DEFAULT_STORAGE_TIMEOUT = 60000;
 
   protected localStorageService: LocalStorageService;
-  protected loginStorageService: LoginStorageService;
+  protected authService: AuthService;
   protected httpClient: HttpClient;
   protected _appConfig: AppConfig;
   protected _url: string;
@@ -47,7 +47,7 @@ export class ORemoteConfigurationService {
   constructor(protected injector: Injector) {
     this.httpClient = this.injector.get(HttpClient);
     this._appConfig = this.injector.get(AppConfig);
-    this.loginStorageService = this.injector.get(LoginStorageService);
+    this.authService = this.injector.get(AuthService);
     this.localStorageService = this.injector.get(LocalStorageService);
 
     this.httpClient = this.injector.get(HttpClient);
@@ -72,7 +72,7 @@ export class ORemoteConfigurationService {
   public getUserConfiguration(): Observable<ServiceResponse> {
     const self = this;
     const observable = new Observable((observer: Subscriber<ServiceResponse>) => {
-      const sessionInfo = self.loginStorageService.getSessionInfo();
+      const sessionInfo = self.authService.getSessionInfo();
       if (!self.hasSession(sessionInfo)) {
         observer.error();
         return;
@@ -103,7 +103,7 @@ export class ORemoteConfigurationService {
       self.storeSubscription.unsubscribe();
     }
     const observable = new Observable((observer: Subscriber<ServiceResponse>) => {
-      const sessionInfo = self.loginStorageService.getSessionInfo();
+      const sessionInfo = self.authService.getSessionInfo();
       if (!self._appConfig.useRemoteConfiguration() || !self.hasSession(sessionInfo)) {
         observer.next();
         observer.complete();
@@ -183,7 +183,7 @@ export class ORemoteConfigurationService {
   }
 
   protected buildHeaders(): HttpHeaders {
-    const sessionInfo = this.loginStorageService.getSessionInfo();
+    const sessionInfo = this.authService.getSessionInfo();
     return new HttpHeaders({
       'Access-Control-Allow-Origin': '*',
       'Content-Type': 'application/json;charset=UTF-8',

--- a/projects/ontimize-web-ngx/src/lib/util/service.utils.ts
+++ b/projects/ontimize-web-ngx/src/lib/util/service.utils.ts
@@ -1,14 +1,13 @@
-import { Router } from '@angular/router';
-
+import { OExpandableContainerComponent } from '../components/expandable-container/o-expandable-container.component';
 import { OFormComponent } from '../components/form/o-form.component';
 import { OFormValue } from '../components/form/OFormValue';
 import { SQLOrder } from '../types/sql-order.type';
 import { Codes } from './codes';
 import { SQLTypes } from './sqltypes';
 import { Util } from './util';
-import { OExpandableContainerComponent } from '../components/expandable-container/o-expandable-container.component';
 
 export class ServiceUtils {
+
   static getParentKeysFromExpandableContainer(parentKeysObject: object, expandableContainer: OExpandableContainerComponent): {} {
     const result = {};
     const ownKeys = Object.keys(parentKeysObject || {});
@@ -160,14 +159,6 @@ export class ServiceUtils {
       });
     }
     return sortColArray;
-  }
-
-  static redirectLogin(router: Router, sessionExpired: boolean = false) {
-    const arg = {};
-    arg[Codes.SESSION_EXPIRED_KEY] = sessionExpired;
-    const extras = {};
-    extras[Codes.QUERY_PARAMS] = arg;
-    router.navigate([Codes.LOGIN_ROUTE], extras);
   }
 
 }


### PR DESCRIPTION
- `LoginService` has been splitted into an abstract class `AuthService` and its implementation `OntimizeAuthService`
- Method `redirectLogin` has been removed. Method `logout` from `AuthService` should provide this functionality. `OntimizeAuthService` still have this method as it is the default ontimize authentication implementation.
- Defined new Injection Token `O_AUTH_SERVICE` for providint/overriding the desired `AuthService` implementation