### PR TITLE
[4.x.x] The table that will not allow scrolling when the user's touch it in tablet mode

### DIFF
--- a/ontimize/components/input/combo/combo-renderer/o-combo-renderer.class.ts
+++ b/ontimize/components/input/combo/combo-renderer/o-combo-renderer.class.ts
@@ -7,7 +7,7 @@ export class OComboCustomRenderer {
 
   public templateref: TemplateRef<any>;
   public comboComponent: OComboComponent;
-  
+
 
   constructor(protected injector: Injector) {
     this.comboComponent = this.injector.get(OComboComponent);
@@ -31,10 +31,10 @@ export class OComboCustomRenderer {
     if (Util.isDefined(value)) {
       parsedValue = value;
     } else {
-      console.warn("getComboData() - No value received");
+      console.warn('getComboData() - No value received');
     }
     return parsedValue;
   }
-  
+
 
 }

--- a/ontimize/components/input/listpicker/listpicker-renderer/o-listpicker-renderer.class.ts
+++ b/ontimize/components/input/listpicker/listpicker-renderer/o-listpicker-renderer.class.ts
@@ -7,7 +7,7 @@ export class OListPickerCustomRenderer {
 
   public templateref: TemplateRef<any>;
   public listpickerComponent: OListPickerComponent;
-  
+
 
   constructor(protected injector: Injector) {
     this.listpickerComponent = this.injector.get(OListPickerComponent);
@@ -31,10 +31,10 @@ export class OListPickerCustomRenderer {
     if (Util.isDefined(value)) {
       parsedValue = value;
     } else {
-      console.warn("getListPickerData() - No value received");
+      console.warn('getListPickerData() - No value received');
     }
     return parsedValue;
   }
-  
+
 
 }

--- a/ontimize/components/table/config/o-table-gesture-config.ts
+++ b/ontimize/components/table/config/o-table-gesture-config.ts
@@ -5,7 +5,7 @@ import { GestureConfig, HammerManager } from '@angular/material';
 export class OTableGestureConfig extends GestureConfig {
   buildHammer(element: HTMLElement) {
     let mc = <HammerManager>super.buildHammer(element);
-    mc.set({ touchAction: "pan-y" });
+    mc.set({ touchAction: 'pan-y' });
     return mc;
   }
 }

--- a/ontimize/components/table/config/o-table-gesture-config.ts
+++ b/ontimize/components/table/config/o-table-gesture-config.ts
@@ -6,6 +6,7 @@ export class OTableGestureConfig extends GestureConfig {
   buildHammer(element: HTMLElement) {
     let mc = <HammerManager>super.buildHammer(element);
     mc.set({ touchAction: 'pan-y' });
+    mc.set({ touchAction: 'pan-x' });
     return mc;
   }
 }

--- a/ontimize/components/table/config/o-table-gesture-config.ts
+++ b/ontimize/components/table/config/o-table-gesture-config.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { GestureConfig, HammerManager } from '@angular/material';
+
+@Injectable()
+export class OTableGestureConfig extends GestureConfig {
+  buildHammer(element: HTMLElement) {
+    let mc = <HammerManager>super.buildHammer(element);
+    mc.set({ touchAction: "pan-y" });
+    return mc;
+  }
+}

--- a/ontimize/components/table/o-table.component.ts
+++ b/ontimize/components/table/o-table.component.ts
@@ -93,6 +93,8 @@ import { OFilterColumn } from './extensions/header/table-columns-filter/columns/
 import { trigger, state, transition, style, animate } from '@angular/animations';
 import { TemplatePortal, DomPortalOutlet } from '@angular/cdk/portal';
 import { OTableRowExpandableComponent, OTableRowExpandedChange } from './extensions/row/table-row-expandable/o-table-row-expandable.component';
+import { HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
+import { OTableGestureConfig } from './config/o-table-gesture-config';
 
 export const NAME_COLUMN_SELECT = 'select';
 export interface OnClickTableEvent {
@@ -2850,6 +2852,9 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
     {
       provide: MatPaginatorIntl,
       useClass: OTableMatPaginatorIntl
+    }, {
+      provide: HAMMER_GESTURE_CONFIG,
+      useClass: OTableGestureConfig
     }
   ]
 })


### PR DESCRIPTION
Scrolling on a touch device doesn't work if the target of the gesture is an element using the matTooltip directive
closes #576 
