### PR TITLE
[8.x.x] O-table-row-expandable: error when exporting table data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## 8.2.4
 ### Bug Fixes
-* **oCurrency, oReal, oInteger, oPercent**: pipes don't update the format of values when language is changed [a9343d0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/a9343d0) Closes ([#566](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/566))
+* **oCurrency, oReal, oInteger, oPercent**: pipes don't update the format of values when language is changed ([a9343d0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/a9343d0)) Closes [#566](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/566)
 
-* **OTranslateHttpLoader**: Remote bundle request: do not parse error object as translations [4670659](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4670659) Closes ([#563](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/563))
+* **OTranslateHttpLoader**: Remote bundle request: do not parse error object as translations ([4670659](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4670659)) Closes [#563](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/563)
 * **o-table**:
-  * **OBaseTableCellEditor**: fixing cell edition bug [6eb72b2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6eb72b2) Closes ([#571](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/571))
-  * **oTableColumnAggregate**: Aggregate column is not updated on changing cell value [de7e77c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/de7e77c)
-  * **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time [16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90)
-  * **o-table-cell-editor-boolean**: fixing cell edition bug [755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4) Closes ([#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573))
-  * Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes ([#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576))
+  * **OBaseTableCellEditor**: fixing cell edition bug ([6eb72b2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6eb72b2)) Closes [#571](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/571)
+  * **oTableColumnAggregate**: Aggregate column is not updated on changing cell value ([de7e77c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/de7e77c))
+  * **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time ([16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90))
+  * **o-table-cell-editor-boolean**: fixing cell edition bug ([755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4)) Closes [#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573)
+  * Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes [#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576)
   * **o-table-row-expandable**: Fixed error when exporting table data ([98bdd0e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/98bdd0e))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 8.2.4
 ### Bug Fixes
-* **oTableColumnAggregate**: Aggregate column is not updated on changing cell value [de7e77c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/de7e77c)
 * **oCurrency, oReal, oInteger, oPercent**: pipes don't update the format of values when language is changed [a9343d0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/a9343d0) Closes ([#566](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/566))
-* **OBaseTableCellEditor**: fixing cell edition bug [6eb72b2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6eb72b2) Closes ([#571](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/571))
+
 * **OTranslateHttpLoader**: Remote bundle request: do not parse error object as translations [4670659](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4670659) Closes ([#563](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/563))
 * **o-table**:
+  * **OBaseTableCellEditor**: fixing cell edition bug [6eb72b2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6eb72b2) Closes ([#571](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/571))
+  * **oTableColumnAggregate**: Aggregate column is not updated on changing cell value [de7e77c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/de7e77c)
   * **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time [16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90)
   * **o-table-cell-editor-boolean**: fixing cell edition bug [755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4) Closes ([#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573))
   * Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes ([#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time [16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90)
   * **o-table-cell-editor-boolean**: fixing cell edition bug [755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4) Closes ([#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573))
   * Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes ([#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576))
-  * **o-table-row-expandable**: Fixed error when exporting table data [98bdd0e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/98bdd0e)
+  * **o-table-row-expandable**: Fixed error when exporting table data ([98bdd0e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/98bdd0e))
 
 
 ## 8.2.3 (2021-04-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 * **oCurrency, oReal, oInteger, oPercent**: pipes don't update the format of values when language is changed [a9343d0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/a9343d0) Closes ([#566](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/566))
 * **OBaseTableCellEditor**: fixing cell edition bug [6eb72b2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6eb72b2) Closes ([#571](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/571))
 * **OTranslateHttpLoader**: Remote bundle request: do not parse error object as translations [4670659](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4670659) Closes ([#563](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/563))
-* **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time [16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90)
-* **o-table-cell-editor-boolean**: fixing cell edition bug [755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4) Closes ([#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573))
-* Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes ([#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576))
+* **o-table**:
+  * **o-table-cell-editor-time**: Fixed not set new value in table-cell-editor-time [16ccf90](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/16ccf90)
+  * **o-table-cell-editor-boolean**: fixing cell edition bug [755daf4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/755daf4) Closes ([#573](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/573))
+  * Fixed prevent touch vertical and horizontal scrolling in table: ([e1b14d1](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e1b14d1)) Closes ([#576](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/576))
+  * **o-table-row-expandable**: Fixed error when exporting table data [98bdd0e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/98bdd0e)
 
 
 ## 8.2.3 (2021-04-09)

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-menu/o-table-menu.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-menu/o-table-menu.component.ts
@@ -304,6 +304,7 @@ export class OTableMenuComponent implements OTableMenu, OnInit, AfterViewInit, O
     // get column's attr whose renderer is OTableCellRendererImageComponent
     const colsNotIncluded: string[] = tableOptions.columns.filter(c => void 0 !== c.renderer && c.renderer instanceof OTableCellRendererImageComponent).map(c => c.attr);
     colsNotIncluded.push(Codes.NAME_COLUMN_SELECT);
+    colsNotIncluded.push(Codes.NAME_COLUMN_EXPANDABLE);
 
     // Table data/filters
     switch (this.table.exportMode) {


### PR DESCRIPTION
Exclude expandable column