### PR TITLE
[4.x.x] Error to export table with expandable row

### DIFF
--- a/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
+++ b/ontimize/components/table/extensions/header/table-menu/o-table-menu.component.ts
@@ -294,6 +294,7 @@ export class OTableMenuComponent implements OnInit, AfterViewInit, OnDestroy {
     // get column's attr whose renderer is OTableCellRendererImageComponent
     let colsNotIncluded: string[] = tableOptions.columns.filter(c => void 0 !== c.renderer && c.renderer instanceof OTableCellRendererImageComponent).map(c => c.attr);
     colsNotIncluded.push(OTableComponent.NAME_COLUMN_SELECT);
+    colsNotIncluded.push(Codes.NAME_COLUMN_EXPANDABLE);
 
     // Table data/filters
     switch (this.table.exportMode) {


### PR DESCRIPTION
The expandable column is added to the array of columns that are not taken into account in the export.