### PR TITLE
[8.x.x] Quickfilter filter-case-sensitive error in console

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1969,7 +1969,7 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
     }
     this.onFilterByColumnChange.emit(this.dataSource.getColumnValueFilters());
     if (this.oTableQuickFilterComponent) {
-      this.oTableQuickFilterComponent.setValue("");
+      this.oTableQuickFilterComponent.setValue(void 0);
     }
   }
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1969,7 +1969,7 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
     }
     this.onFilterByColumnChange.emit(this.dataSource.getColumnValueFilters());
     if (this.oTableQuickFilterComponent) {
-      this.oTableQuickFilterComponent.setValue(void 0);
+      this.oTableQuickFilterComponent.setValue("");
     }
   }
 
@@ -2338,16 +2338,18 @@ export class OTableComponent extends OServiceComponent implements OnInit, OnDest
       filterCaseSensitive will be the value in local storage
     */
     if (Util.isDefined(this.filterCaseSensitive) && this.state.hasOwnProperty('initial-configuration') &&
-      this.state['initial-configuration'].hasOwnProperty('filter-case-sensitive') &&
+      this.state['initial-configuration'].hasOwnProperty('filter-case-sensitive') && conf.hasOwnProperty('initial-configuration') &&
       this.filterCaseSensitive === conf['initial-configuration']['filter-case-sensitive']) {
       this.filterCaseSensitive = conf.hasOwnProperty('filter-case-sensitive') ? conf['filter-case-sensitive'] : this.filterCaseSensitive;
+    } else {
+      this.filterCaseSensitive = conf.hasOwnProperty('filter-case-sensitive') ? conf['filter-case-sensitive'] : (Util.isDefined(this.filterCaseSensitive) ? this.filterCaseSensitive : false);
     }
 
     const storedColumnFilters = this.oTableStorage.getStoredColumnsFilters(conf);
 
 
     if (Util.isDefined(this.filterColumnActiveByDefault) && this.state.hasOwnProperty('initial-configuration') &&
-      this.state['initial-configuration'].hasOwnProperty('filter-column-active-by-default') &&
+      this.state['initial-configuration'].hasOwnProperty('filter-column-active-by-default')  && conf.hasOwnProperty('initial-configuration') &&
       this.originalFilterColumnActiveByDefault !== conf['initial-configuration']['filter-column-active-by-default']) {
       this.showFilterByColumnIcon = this.originalFilterColumnActiveByDefault;
     } else {


### PR DESCRIPTION
Added comprobation to check if initial-configuration is setted and has values to avoid filter-case-sensitive error in console.