### PR TITLE
New method destroy in o-table-datasource

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
@@ -1,7 +1,7 @@
 import { DataSource, ListRange } from '@angular/cdk/collections';
 import { EventEmitter } from '@angular/core';
 import { MatPaginator } from '@angular/material';
-import { BehaviorSubject, merge, Observable, Subject,Subscription } from 'rxjs';
+import { BehaviorSubject, merge, Observable, Subject, Subscription } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 
 
@@ -173,7 +173,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
             because at next the CustomVirtualScrollStrategy will emit event OnRangeChangeVirtualScroll 
           */
           if (this.table.scrollStrategy && !this._paginator) {
-            data = this.getVirtualScrollData(data, new OnRangeChangeVirtualScroll({ start: 0, end: Codes.LIMIT_SCROLLVIRTUAL}));
+            data = this.getVirtualScrollData(data, new OnRangeChangeVirtualScroll({ start: 0, end: Codes.LIMIT_SCROLLVIRTUAL }));
           }
 
           this.aggregateData = this.getAggregatesData(this.renderedData);
@@ -290,6 +290,13 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
   }
 
   disconnect() {
+    //no-op because the destroy method will be called instead
+  }
+
+  destroy() {
+    /* The table template is modified according to whether it is groupable or not,
+     so the destroy method is defined to launch when the table component is destroyed
+     */
     this.onRenderedDataChange.complete();
     this.dataTotalsChange.complete();
     this._quickFilterChange.complete();
@@ -553,7 +560,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
         return acumulator + (isNaN(currentValue[column]) ? 0 : currentValue[column]);
       }, value);
     }
-    return  +(value).toFixed(2);
+    return +(value).toFixed(2);
   }
 
   protected count(column, data): number {

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -835,6 +835,9 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     if (this.contextMenuSubscription) {
       this.contextMenuSubscription.unsubscribe();
     }
+    if (this.dataSource) {
+      this.dataSource.destroy();
+    }
     Object.keys(this.asyncLoadSubscriptions).forEach(idx => {
       if (this.asyncLoadSubscriptions[idx]) {
         this.asyncLoadSubscriptions[idx].unsubscribe();
@@ -1419,9 +1422,9 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
 
   initViewPort(data: any[]) {
     if (this.scrollStrategy) {
-      const headerElRef = this.elRef.nativeElement.querySelector(headerSelector)
-      const footerElRef = this.elRef.nativeElement.querySelector(footerSelector)
-      const rowElRef = this.elRef.nativeElement.querySelector(rowSelector)
+      const headerElRef = this.elRef.nativeElement.querySelector(headerSelector);
+      const footerElRef = this.elRef.nativeElement.querySelector(footerSelector);
+      const rowElRef = this.elRef.nativeElement.querySelector(rowSelector);
 
       const headerHeight = headerElRef ? headerElRef.offsetHeight : 0;
       const footerHeight = footerElRef ? footerElRef.offsetHeight : 0;
@@ -2786,7 +2789,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
    */
   getColumnDataByAttr(attr, row: any): any {
     const oCol = this.getOColumn(attr);
-    if (!Util.isDefined(oCol)){
+    if (!Util.isDefined(oCol)) {
       return row[attr];
     }
     const useRenderer = oCol.renderer && oCol.renderer.getCellData;

--- a/projects/ontimize-web-ngx/src/lib/interfaces/o-table-datasource.interface.ts
+++ b/projects/ontimize-web-ngx/src/lib/interfaces/o-table-datasource.interface.ts
@@ -32,4 +32,5 @@ export interface OTableDataSource {
   updateGroupedColumns();
   toggleGroupByColumn(rowGroup: OTableGroupedRow);
   setRowGroupLevelExpansion(rowGroup: OTableGroupedRow, value: boolean);
+  destroy(): void;
 }


### PR DESCRIPTION
The destroy method is defined to launch when the table component is destroyed instead of disconnet method