### PR TITLE
[8.x.x] New input virtual-scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   * Adding new optional parameter (indicating the new sort columns) to the `reinitializeSortColumns` method and changing its access level to public.([#628](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/628)) ([c413ece](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c413ece))
   * **o-table-cell-editor-email**: new component for email cell editors([6fdf754](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6fdf754))
   * Adding virtual scroll ([#598](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/598)) ([e14c424](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e14c424) ([238da22](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/238da22) ([b5668c3](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b5668c3)
+  
+    *NOTE*: Set min-height='400px' in o-table, you can modify the height table in .o-table class
+
   * Added validators functionality to cell editors and insertable row ([4d66853](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4d66853)) Closes [#517](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/517)
   * Row grouping new features [#597](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/597):
     * **o-table-columns-grouping**: new `o-table` inner component used to configure the row grouping columns

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
@@ -14,7 +14,7 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
     public renderedRangeStream = new BehaviorSubject<ListRange>({ start: 0, end: 0 });
     public stickyChange = new Subject<number>();
     buffer: number;
-    bufferMultiplier: number = 0.5;
+    bufferMultiplier: number = 1;
 
     constructor() {
         this.scrolledIndexChange = this.indexChange.asObservable().pipe(distinctUntilChanged());
@@ -34,7 +34,7 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
 
     attach(viewport: CdkVirtualScrollViewport): void {
         this.viewport = viewport;
-        this.viewport.renderedRangeStream.subscribe(this.renderedRangeStream);
+        this.viewport.renderedRangeStream.pipe(distinctUntilChanged()).subscribe(this.renderedRangeStream);
 
         this.onDataLengthChanged();
         this.updateContent();
@@ -45,6 +45,7 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
         this.stickyChange.complete();
         this.renderedRangeStream.complete();
     }
+
     public onContentRendered(): void {
         // no-op
     }
@@ -66,7 +67,6 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
             this.rowHeight === rowHeight
             && this.headerHeight === headerHeight
             && this.footerHeight === footerHeight
-
         ) {
             return;
         }
@@ -99,12 +99,12 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
         const start = Math.max(0, index - buffer);
         const end = Math.min(this.dataLength, index + amount + buffer);
         const renderedOffset = start * this.rowHeight;
-
+    
         this.viewport.setRenderedContentOffset(renderedOffset);
         this.viewport.setRenderedRange({ start, end });
 
         this.indexChange.next(index);
         this.stickyChange.next(renderedOffset);
-
+       
     }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
@@ -105,6 +105,5 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
 
         this.indexChange.next(index);
         this.stickyChange.next(renderedOffset);
-       
     }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -24,6 +24,7 @@ $o_table_row_padding: 24px;
     align-items: flex-start;
     align-content: stretch;
     min-width: 100%;
+    min-height: 400px;
 
     .o-table-body {
       display: flex;

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -619,7 +619,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     private appRef: ApplicationRef,
     private _componentFactoryResolver: ComponentFactoryResolver,
     @Optional() @Inject(forwardRef(() => OFormComponent)) form: OFormComponent,
-    @Optional() @Inject(VIRTUAL_SCROLL_STRATEGY) public scrollStrategy: OTableVirtualScrollStrategy
+    @Optional() @Inject(VIRTUAL_SCROLL_STRATEGY) public readonly scrollStrategy: OTableVirtualScrollStrategy
   ) {
     super(injector, elRef, form);
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1,7 +1,7 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { SelectionChange, SelectionModel } from '@angular/cdk/collections';
 import { DomPortalOutlet, TemplatePortal } from '@angular/cdk/portal';
-import { VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
+import { CdkVirtualScrollViewport, VIRTUAL_SCROLL_STRATEGY } from '@angular/cdk/scrolling';
 import {
   AfterViewInit,
   ApplicationRef,
@@ -268,16 +268,16 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   protected snackBarService: SnackBarService;
 
   public paginator: OTablePaginator;
-  private virtualScrollViewport: OTableVirtualScrollStrategy;
+  private virtualScrollViewport: CdkVirtualScrollViewport;
   public activeVirtualScroll = true;
 
   @ViewChild(MatPaginator, { static: false }) matpaginator: MatPaginator;
   @ViewChild(OMatSort, { static: false }) sort: OMatSort;
 
-  @ViewChild('virtualScrollViewPort', { static: false }) set cdkVirtualScrollViewport(value: OTableVirtualScrollStrategy) {
+  @ViewChild('virtualScrollViewPort', { static: false }) set cdkVirtualScrollViewport(value: CdkVirtualScrollViewport) {
     if (value != this.virtualScrollViewport) {
       this.virtualScrollViewport = value;
-      this.activeVirtualScroll = value instanceof OTableVirtualScrollStrategy;
+      this.activeVirtualScroll = value instanceof CdkVirtualScrollViewport;
       this.setDatasource();
     }
   }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -28,7 +28,7 @@ import {
   ViewRef
 } from '@angular/core';
 import { MatCheckboxChange, MatDialog, MatMenu, MatPaginator, MatTab, MatTabGroup, PageEvent } from '@angular/material';
-import { BehaviorSubject, combineLatest, Observable, of, Subscription, timer } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, of, Subscription } from 'rxjs';
 import { distinctUntilChanged, filter, map } from 'rxjs/operators';
 
 import { BooleanConverter, InputConverter } from '../../decorators/input-converter';

--- a/projects/ontimize-web-ngx/src/lib/interfaces/o-table-datasource.interface.ts
+++ b/projects/ontimize-web-ngx/src/lib/interfaces/o-table-datasource.interface.ts
@@ -32,5 +32,4 @@ export interface OTableDataSource {
   updateGroupedColumns();
   toggleGroupByColumn(rowGroup: OTableGroupedRow);
   setRowGroupLevelExpansion(rowGroup: OTableGroupedRow, value: boolean);
-  destroy(): void;
 }


### PR DESCRIPTION
- New input  `virtual-scroll`
- Set min-height=400px in o-table-container class
- Refresh datasource in the table when refresh cdkVirtualScrollViewport viewchild
- Remove destroy method in o-table-datasource.service.ts (Revert commit 52aff20)