### PR TITLE
[8.x.x] o-table doesn't work with select-all-checkbox-visible="yes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## 8.5.0
 ### Features
-* **o-form-layout-tabgroup-options**: new `max-tabs` input ([9d78d40](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/9d78d40)) Closes [#694](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/694) 
+* **o-form-layout-tabgroup-options**: new `max-tabs` input ([9d78d40](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/9d78d40)) Closes [#694](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/694)
 * **OFormServiceComponent** (**o-combo**, **o-list-picker**, **o-radio**) ([e92a78e5](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e92a78e5)) Closes [#706](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/706)
   * Showing a context menu with the reload data option
   * New `refresh` method
-* **o-table** ([2f5b2bb9](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/2f5b2bb9)) Closes [#620](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/620) 
+* **o-table** ([2f5b2bb9](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/2f5b2bb9)) Closes [#620](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/620)
   * Showing all the available values after the first configuration of a column filter
   * **OColumnValueFilter**: adding `availableValues` to stored filter properties
 * **o-app-layout-sidenav**: implementing multilevel navigation but only construction up to the 3rd level is recommended ([4daab8d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4daab8d)) ([6cbbaa9](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6cbbaa9))  Closes [#709](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/709)
+
+### Bug fixes
+* **o-table**: fixing bug when select-all-checkbox-visible="yes" Closes [#714](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/714) ([b88be9b](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b88be9b))
 
 ### BREAKING CHANGES
 * **o-app-layout-sidenav**: ([2fc889e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/2fc889e))

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -278,7 +278,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     if (value != this.virtualScrollViewport) {
       this.virtualScrollViewport = value;
       this.activeVirtualScroll = value instanceof CdkVirtualScrollViewport;
-      if(this.activeVirtualScroll){
+      if (this.activeVirtualScroll) {
         this.updateHeaderAndFooterStickyPositions();
       }
       this.setDatasource();
@@ -416,7 +416,10 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   }
   protected _selectAllCheckboxVisible: boolean;
   set selectAllCheckboxVisible(value: boolean) {
-    this._selectAllCheckboxVisible = BooleanConverter(this.state.selectColumnVisible) || BooleanConverter(value);
+    this._selectAllCheckboxVisible = BooleanConverter(value);
+    if (this.state) {
+      this._selectAllCheckboxVisible = BooleanConverter(this.state.selectColumnVisible);
+    }
     this._oTableOptions.selectColumn.visible = this._selectAllCheckboxVisible;
     this.initializeCheckboxColumn();
   }
@@ -871,7 +874,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     if (this.virtualScrollSubscription) {
       this.virtualScrollSubscription.unsubscribe();
     }
-    if(this.scrollStrategy){
+    if (this.scrollStrategy) {
       this.scrollStrategy.destroy();
     }
 

--- a/projects/ontimize-web-ngx/src/lib/services/state/o-table-component-state.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/state/o-table-component-state.service.ts
@@ -99,7 +99,7 @@ export class OTableComponentStateService extends AbstractComponentStateService<O
         result = this.getPageState();
         break;
       case 'selection':
-        result = this.getSelectionState();
+        result['selection'] = this.getSelectionState();
         break;
       case 'initial-configuration':
         result = this.getInitialConfigurationState();


### PR DESCRIPTION
- Closes #714 
- Fixing bug that the selected records are not being saved in the local storage.