### PR TITLE
[8.x.x] o-table: blank screen on virtual scroll with mat tab group 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Bug fixes
 * **o-table**:
   * Fix bug in row grouping when collapsing row groups makes columns aggregate have a wrong value ([b4920cd](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b4920cd)) Closes [#741](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/741)
+  * Fix bug when open a detail with o-form-layout-manager  ([f5612a4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/f5612a4)) Closes [#751](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/751),[#752](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/752)
+  * Fixed the bug that the table is displayed blank when navigating the mat tab group and virtual scrolling is enabled([6327825](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6327825)) Closes [#751](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/751)
 ## 8.5.0
 
 ### We are restyling **OntimizeWeb**

--- a/projects/ontimize-web-ngx/src/lib/components/o-service-component.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/o-service-component.class.ts
@@ -133,6 +133,9 @@ export abstract class AbstractOServiceComponent<T extends AbstractComponentState
   protected rowHeightSubject: BehaviorSubject<string> = new BehaviorSubject(this._rowHeight);
   public rowHeightObservable: Observable<string> = this.rowHeightSubject.asObservable();
 
+  protected checkViewPortSubject: BehaviorSubject<boolean> = new BehaviorSubject(false);
+  public checkViewPortObservable: Observable<boolean> = this.checkViewPortSubject.asObservable();
+
   set rowHeight(value) {
     this._rowHeight = value ? value.toLowerCase() : value;
     if (!Codes.isValidRowHeight(this._rowHeight)) {
@@ -698,6 +701,7 @@ export abstract class AbstractOServiceComponent<T extends AbstractComponentState
             updateComponentStateSubject.next(arg);
           }
         }
+        this.checkViewPortSubject.next(true)
       });
 
       this.tabsSubscriptions.add(updateComponentStateSubject.subscribe((arg) => {

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
@@ -71,7 +71,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
     }
 
     if (this.table.activeVirtualScroll) {
-      this.table.scrollStrategy.renderedRangeStream
+      this.table.virtualScrollViewport.renderedRangeStream
         .pipe(distinctUntilChanged())
         .subscribe(
           (value: ListRange) => {
@@ -170,9 +170,9 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
 
           this.renderedData = data;
 
-          /* 
+          /*
             when the data is very large, the application crashes so it gets a limited range of data the first time
-            because at next the CustomVirtualScrollStrategy will emit event OnRangeChangeVirtualScroll 
+            because at next the CustomVirtualScrollStrategy will emit event OnRangeChangeVirtualScroll
           */
           if (this.table.activeVirtualScroll && !this._paginator) {
             data = this.getVirtualScrollData(data, new OnRangeChangeVirtualScroll({ start: 0, end: Codes.LIMIT_SCROLLVIRTUAL }));

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
@@ -36,6 +36,10 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
   }
 
   public detach(): void {
+    //no-op
+  }
+
+  public destroy(): void {
     this.indexChange.complete();
     this.stickyChange.complete();
   }
@@ -48,7 +52,7 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
     // no-op
   }
 
-  public scrollToIndex(index: number, behavior: ScrollBehavior): void {
+  public scrollToIndex(index: number, behavior?: ScrollBehavior): void {
     // no-op
   }
 
@@ -58,9 +62,9 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
 
   public setConfig(rowHeight: number, headerHeight: number, footerHeight: number) {
     if (
-      this.rowHeight === rowHeight
-      && this.headerHeight === headerHeight
-      && this.footerHeight === footerHeight
+      (this.rowHeight === rowHeight
+        && this.headerHeight === headerHeight
+        && this.footerHeight === footerHeight) || rowHeight === 0
     ) {
       return;
     }
@@ -96,7 +100,6 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
 
     this.viewport.setRenderedContentOffset(renderedOffset);
     this.viewport.setRenderedRange({ start, end });
-
     this.indexChange.next(index);
     this.stickyChange.next(renderedOffset);
   }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
@@ -1,110 +1,103 @@
-import { ListRange } from "@angular/cdk/collections";
 import { CdkVirtualScrollViewport, VirtualScrollStrategy } from "@angular/cdk/scrolling";
-import { BehaviorSubject, Observable, Subject } from "rxjs";
+import { Observable, Subject } from "rxjs";
 import { distinctUntilChanged } from "rxjs/operators";
 
 export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
-    private viewport: CdkVirtualScrollViewport;
+  private viewport: CdkVirtualScrollViewport;
 
-    private rowHeight!: number;
-    private headerHeight!: number;
-    private footerHeight!: number;
-    public readonly indexChange = new Subject<number>();
-    public scrolledIndexChange: Observable<number>;
-    public renderedRangeStream = new BehaviorSubject<ListRange>({ start: 0, end: 0 });
-    public stickyChange = new Subject<number>();
-    buffer: number;
-    bufferMultiplier: number = 1;
+  private rowHeight!: number;
+  private headerHeight!: number;
+  private footerHeight!: number;
+  public readonly indexChange = new Subject<number>();
+  public scrolledIndexChange: Observable<number>;
+  public stickyChange = new Subject<number>();
+  buffer: number;
+  bufferMultiplier: number = 1;
 
-    constructor() {
-        this.scrolledIndexChange = this.indexChange.asObservable().pipe(distinctUntilChanged());
+  constructor() {
+    this.scrolledIndexChange = this.indexChange.asObservable().pipe(distinctUntilChanged());
+  }
+
+  get dataLength(): number {
+    return this._dataLength;
+  }
+
+  set dataLength(value: number) {
+    this._dataLength = value;
+    this.onDataLengthChanged();
+  }
+
+  private _dataLength = 0;
+
+  attach(viewport: CdkVirtualScrollViewport): void {
+    this.viewport = viewport;
+    this.onDataLengthChanged();
+    this.updateContent();
+  }
+
+  public detach(): void {
+    this.indexChange.complete();
+    this.stickyChange.complete();
+  }
+
+  public onContentRendered(): void {
+    // no-op
+  }
+
+  public onRenderedOffsetChanged(): void {
+    // no-op
+  }
+
+  public scrollToIndex(index: number, behavior: ScrollBehavior): void {
+    // no-op
+  }
+
+  public onContentScrolled(): void {
+    this.updateContent();
+  }
+
+  public setConfig(rowHeight: number, headerHeight: number, footerHeight: number) {
+    if (
+      this.rowHeight === rowHeight
+      && this.headerHeight === headerHeight
+      && this.footerHeight === footerHeight
+    ) {
+      return;
     }
+    this.rowHeight = rowHeight;
+    this.headerHeight = headerHeight;
+    this.footerHeight = footerHeight;
+    //if change heights, then update content size
+    this.onDataLengthChanged();
+  }
 
-    get dataLength(): number {
-        return this._dataLength;
+  public onDataLengthChanged(): void {
+    if (this.viewport) {
+      this.viewport.setTotalContentSize(this.dataLength * this.rowHeight + this.headerHeight + this.footerHeight);
+      this.viewport.scrollToOffset(0);//set scroll up
+      this.updateContent();
     }
+  }
 
-    set dataLength(value: number) {
-        this._dataLength = value;
-        this.onDataLengthChanged();
+  private updateContent() {
+    if (!this.viewport || !this.rowHeight) {
+      return;
     }
+    const scrollOffset = this.viewport.measureScrollOffset();
+    const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
+    const offset = Math.max(scrollOffset - this.headerHeight, 0);
+    const buffer = Math.ceil(amount * this.bufferMultiplier);
 
-    private _dataLength = 0;
+    const skip = Math.round(offset / this.rowHeight);
+    const index = Math.max(0, skip);
+    const start = Math.max(0, index - buffer);
+    const end = Math.min(this.dataLength, index + amount + buffer);
+    const renderedOffset = start * this.rowHeight;
 
-    attach(viewport: CdkVirtualScrollViewport): void {
-        this.viewport = viewport;
-        this.onDataLengthChanged();
-        this.updateContent();
-    }
+    this.viewport.setRenderedContentOffset(renderedOffset);
+    this.viewport.setRenderedRange({ start, end });
 
-    public detach(): void {
-        //no-op
-    }
-
-    public destroy(): void {
-        this.indexChange.complete();
-        this.stickyChange.complete();
-        this.renderedRangeStream.complete();
-    }
-
-    public onContentRendered(): void {
-        // no-op
-    }
-
-    public onRenderedOffsetChanged(): void {
-        // no-op
-    }
-
-    public scrollToIndex(index: number, behavior: ScrollBehavior): void {
-        // no-op
-    }
-
-    public onContentScrolled(): void {
-        this.updateContent();
-    }
-
-    public setConfig(rowHeight: number, headerHeight: number, footerHeight: number) {
-        if (
-            this.rowHeight === rowHeight
-            && this.headerHeight === headerHeight
-            && this.footerHeight === footerHeight
-        ) {
-            return;
-        }
-        this.rowHeight = rowHeight;
-        this.headerHeight = headerHeight;
-        this.footerHeight = footerHeight;
-        //if change heights, then update content size
-        this.onDataLengthChanged();
-    }
-
-    public onDataLengthChanged(): void {
-        if (this.viewport) {
-            this.viewport.setTotalContentSize(this.dataLength * this.rowHeight + this.headerHeight + this.footerHeight);
-            this.viewport.scrollToOffset(0);//set scroll up 
-            this.updateContent();
-        }
-    }
-
-    private updateContent() {
-        if (!this.viewport || !this.rowHeight) {
-            return;
-        }
-        const scrollOffset = this.viewport.measureScrollOffset();
-        const amount = Math.ceil(this.viewport.getViewportSize() / this.rowHeight);
-        const offset = Math.max(scrollOffset - this.headerHeight, 0);
-        const buffer = Math.ceil(amount * this.bufferMultiplier);
-
-        const skip = Math.round(offset / this.rowHeight);
-        const index = Math.max(0, skip);
-        const start = Math.max(0, index - buffer);
-        const end = Math.min(this.dataLength, index + amount + buffer);
-        const renderedOffset = start * this.rowHeight;
-
-        this.viewport.setRenderedContentOffset(renderedOffset);
-        this.renderedRangeStream.next({ start, end });
-
-        this.indexChange.next(index);
-        this.stickyChange.next(renderedOffset);
-    }
+    this.indexChange.next(index);
+    this.stickyChange.next(renderedOffset);
+  }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/o-table-strategy.service.ts
@@ -11,8 +11,7 @@ export class OTableVirtualScrollStrategy implements VirtualScrollStrategy {
   public readonly indexChange = new Subject<number>();
   public scrolledIndexChange: Observable<number>;
   public stickyChange = new Subject<number>();
-  buffer: number;
-  bufferMultiplier: number = 1;
+  private bufferMultiplier: number = 1;
 
   constructor() {
     this.scrolledIndexChange = this.indexChange.asObservable().pipe(distinctUntilChanged());

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1492,7 +1492,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       const rowHeight = rowElRef ? rowElRef.offsetHeight : OTableComponent.DEFAULT_ROW_HEIGHT;
 
       //set config viewport
-      this.scrollStrategy.setConfig(this.fixedHeader, rowHeight, headerHeight, footerHeight);
+      this.scrollStrategy.setConfig(rowHeight, headerHeight, footerHeight);
       if (this.previousRendererData !== this.dataSource.renderedData) {
         console.log(' this.scrollStrategy.dataLength ', this.previousRendererData, this.dataSource.renderedData);
         this.scrollStrategy.dataLength = data.length;

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1494,7 +1494,6 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       //set config viewport
       this.scrollStrategy.setConfig(rowHeight, headerHeight, footerHeight);
       if (this.previousRendererData !== this.dataSource.renderedData) {
-        console.log(' this.scrollStrategy.dataLength ', this.previousRendererData, this.dataSource.renderedData);
         this.scrollStrategy.dataLength = data.length;
       }
     }


### PR DESCRIPTION
Fixes #756 

- It's necessary to trigger **viewport.checkViewportSize**() on tab change.

> Its a temporarily fixed, waiting for the official fix for  [#10117](https://github.com/angular/components/issues/10117)

- Replaced own renderedRangeStream in virtual scroll strategy to viewport.renderedRangeStream