### PR TITLE
[8.x.x] o-table: virtual scrolling works abnormally sometimes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@
 * **o-table**:
   * Fix bug in row grouping when collapsing row groups makes columns aggregate have a wrong value ([b4920cd](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b4920cd)) Closes [#741](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/741)
   * Fix bug when open a detail with o-form-layout-manager  ([f5612a4](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/f5612a4)) Closes [#751](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/751),[#752](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/752)
-  * Fixed the bug that the table is displayed blank when navigating the mat tab group and virtual scrolling is enabled([6327825](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6327825)) Closes [#751](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/751)
+  * Fix the bug that the table is displayed blank when navigating the mat tab group and virtual scrolling is enabled([6327825](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/6327825)) Closes [#751](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/751)
+  * Fix the bug that the virtual scrolling works abnormally sometimes ([3b7d0ca](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/3b7d0ca)) Closes [#760](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/760)
+
 
 ### BREAKING CHANGES
 * Changes made to solve [#745](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/745) and [#754](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/754) ([d1829ef](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/d1829ef)) ([7c4dc447](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/7c4dc447)). This changes will be transparent to user.
   * **o-form-layout-manager**, **OFormLayoutManagerMode**: `setModifiedState` method arguments updated
   * **OFormNavigationClass**:
-    * `setModifiedState` method is now protected	
+    * `setModifiedState` method is now protected
     * `suscribeToCacheChanges` method has no arguments now
-  * **OFormCacheClass**: `onCacheEmptyStateChanges` emmiter no longer exists  
+  * **OFormCacheClass**: `onCacheEmptyStateChanges` emmiter no longer exists
   * **OFormLayoutManagerMode**: `canAddDetailComponent` method now can also return an Observable
   * **OFormLayoutManager**: `canAddDetailComponent` now returns an Observable
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
@@ -139,7 +139,6 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
         if (x instanceof OnRangeChangeVirtualScroll) {
           // render subset (range) of renderedData when new OnRangeChangeVirtualScroll event is emitted
           data = this.getVirtualScrollData(this.renderedData, x);
-          console.log('data ', data);
         } else {
           /*
             it is necessary to first calculate the calculated columns and

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
@@ -70,7 +70,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
       this._paginator = table.matpaginator;
     }
 
-    if (this.table.activeVirtualScroll) {
+    if (this.table.virtualScrollViewport) {
       this.table.virtualScrollViewport.renderedRangeStream
         .pipe(distinctUntilChanged())
         .subscribe(
@@ -121,7 +121,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
       }
     }
 
-    if (this.table.activeVirtualScroll) {
+    if (this.table.virtualScrollViewport) {
       displayDataChanges.push(this._virtualPageChange);
     }
 
@@ -139,6 +139,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
         if (x instanceof OnRangeChangeVirtualScroll) {
           // render subset (range) of renderedData when new OnRangeChangeVirtualScroll event is emitted
           data = this.getVirtualScrollData(this.renderedData, x);
+          console.log('data ', data);
         } else {
           /*
             it is necessary to first calculate the calculated columns and
@@ -174,7 +175,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
             when the data is very large, the application crashes so it gets a limited range of data the first time
             because at next the CustomVirtualScrollStrategy will emit event OnRangeChangeVirtualScroll
           */
-          if (this.table.activeVirtualScroll && !this._paginator) {
+          if (this.table.virtualScrollViewport && !this._paginator) {
             data = this.getVirtualScrollData(data, new OnRangeChangeVirtualScroll({ start: 0, end: Codes.LIMIT_SCROLLVIRTUAL }));
           }
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -1482,7 +1482,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
 
   initViewPort(data: any[]) {
 
-    if (this.virtualScrollViewport) {
+    if (this.virtualScrollViewport && data) {
       const headerElRef = this.elRef.nativeElement.querySelector(headerSelector);
       const footerElRef = this.elRef.nativeElement.querySelector(footerSelector);
       const rowElRef = this.elRef.nativeElement.querySelector(rowSelector);
@@ -1523,8 +1523,9 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }, 500);
     this.loadingScrollSubject.next(false);
 
+    this.initViewPort(this.dataSource.renderedData);
+
     if (this.previousRendererData !== this.dataSource.renderedData) {
-      this.initViewPort(this.dataSource.renderedData);
       this.previousRendererData = this.dataSource.renderedData;
       ObservableWrapper.callEmit(this.onContentChange, this.dataSource.renderedData);
     }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -692,7 +692,6 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
         distinctUntilChanged(),
         filter(() => this.fixedHeader || this.hasInsertableRow())
       ).subscribe(x => {
-        console.log('scrollStrategy.stickyChange', x);
         this.elRef.nativeElement.querySelectorAll(stickyHeaderSelector).forEach((el: HTMLElement) => {
           el.style.top = - x + 'px';
         });

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -16,6 +16,7 @@ import {
   HostListener,
   Inject,
   Injector,
+  NgZone,
   OnDestroy,
   OnInit,
   Optional,
@@ -688,15 +689,18 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }
 
     if (this.virtualScrollViewport) {
+      const zone = this.injector.get(NgZone);
       this.virtualScrollSubscription = this.scrollStrategy.stickyChange.pipe(
         distinctUntilChanged(),
         filter(() => this.fixedHeader || this.hasInsertableRow())
       ).subscribe(x => {
-        this.elRef.nativeElement.querySelectorAll(stickyHeaderSelector).forEach((el: HTMLElement) => {
-          el.style.top = - x + 'px';
-        });
-        this.elRef.nativeElement.querySelectorAll(stickyFooterSelector).forEach((el: HTMLElement) => {
-          el.style.bottom = x + 'px';
+        zone.run(() => {
+          this.elRef.nativeElement.querySelectorAll(stickyHeaderSelector).forEach((el: HTMLElement) => {
+            el.style.top = - x + 'px';
+          });
+          this.elRef.nativeElement.querySelectorAll(stickyFooterSelector).forEach((el: HTMLElement) => {
+            el.style.bottom = x + 'px';
+          });
         });
       });
     }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -269,8 +269,6 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
 
   public paginator: OTablePaginator;
 
-  public activeVirtualScroll = true;
-
   @ViewChild(MatPaginator, { static: false }) matpaginator: MatPaginator;
   @ViewChild(OMatSort, { static: false }) sort: OMatSort;
 
@@ -278,13 +276,12 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   @ViewChild('virtualScrollViewPort', { static: false }) set cdkVirtualScrollViewport(value: CdkVirtualScrollViewport) {
     if (value != this.virtualScrollViewport) {
       this.virtualScrollViewport = value;
-      this.activeVirtualScroll = value instanceof CdkVirtualScrollViewport;
       this.updateHeaderAndFooterStickyPositions();
       if (this.checkViewportSizeSubscription) {
         this.checkViewportSizeSubscription.unsubscribe();
       }
 
-      if (this.activeVirtualScroll) {
+      if (this.virtualScrollViewport) {
         this.checkViewportSizeSubscription = this.checkViewPortSubject.subscribe(x => {
           if (x) {
             this.checkViewportSize();
@@ -690,12 +687,12 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       this.virtualScrollSubscription.unsubscribe();
     }
 
-    if (this.activeVirtualScroll) {
+    if (this.virtualScrollViewport) {
       this.virtualScrollSubscription = this.scrollStrategy.stickyChange.pipe(
         distinctUntilChanged(),
         filter(() => this.fixedHeader || this.hasInsertableRow())
       ).subscribe(x => {
-
+        console.log('scrollStrategy.stickyChange', x);
         this.elRef.nativeElement.querySelectorAll(stickyHeaderSelector).forEach((el: HTMLElement) => {
           el.style.top = - x + 'px';
         });
@@ -1482,7 +1479,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
 
   initViewPort(data: any[]) {
 
-    if (this.activeVirtualScroll) {
+    if (this.virtualScrollViewport) {
       const headerElRef = this.elRef.nativeElement.querySelector(headerSelector);
       const footerElRef = this.elRef.nativeElement.querySelector(footerSelector);
       const rowElRef = this.elRef.nativeElement.querySelector(rowSelector);
@@ -1523,9 +1520,8 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }, 500);
     this.loadingScrollSubject.next(false);
 
-    this.initViewPort(this.dataSource.renderedData);
-
     if (this.previousRendererData !== this.dataSource.renderedData) {
+      this.initViewPort(this.dataSource.renderedData);
       this.previousRendererData = this.dataSource.renderedData;
       ObservableWrapper.callEmit(this.onContentChange, this.dataSource.renderedData);
     }


### PR DESCRIPTION
Fixes #760
Modify the strategy to return data range
ActiveVirtualScroll variable has removed