### PR TITLE
[8.x.x] Row grouping: align aggregation title depending on column type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * **Util**: adding new `wrapIntoObservable` method ([1c7523c2](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1c7523c2))
 * **OFormLayoutManager**: new `hasToConfirmExit` method ([7c4dc447](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/7c4dc447))
 * **o-table**:
-  * alignment on aggregate column heading with same default column type alignment ([5bfa41d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/5bfa41d)) Closes [#740](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/740)
+  * alignment on aggregate column heading with same default column type alignment ([5bfa41d](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/5bfa41d))([4adeb84](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/4adeb84)) Closes [#740](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/740)
   * new `context-menu` input ([04ffbe69](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/04ffbe69))
 ### Bug fixes
 * **o-table**:

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -252,6 +252,7 @@ $o_table_row_padding: 24px;
               width:100%;
               left:0;
               top:0;
+              text-align: left;
             }
             .grouping-aggregate {
               font-weight: bold;


### PR DESCRIPTION
Grouping title wrapper always is aligned to left
Fixes #740 