### PR TITLE
[8.x.x]o-table: export screen is displayed incorrectly 

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/export/o-table-export-dialog.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/export/o-table-export-dialog.component.scss
@@ -5,4 +5,14 @@
     height: 48px;
     font-size: 48px;
   }
+
+  .mat-raised-button {
+    height: initial;
+
+    .mat-button-wrapper {
+      > div {
+        line-height: inherit;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #770
Set height butron to initial value