### PR TITLE
bug in o-table: filter by column when the column has a custom renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
   ontimize-web-ngx/issues/751)
   * Fix the bug when `title` attribute is defined in `o-table-column` and it does not show the translated value in o-table-context-menu ([c259570](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c259570)) Closes [#766](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/766)
   * Fixing `expand-groups-same-level` input bug ([edd9e787](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/edd9e787)) Closes [#746](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/746)
+  * Fixing the bug in the column filtering modal when using a custom renderer ([4f878d8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/
+4f878d8)) Closes [#777](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/777)
+
 * **o-form-layout-manager**: Fix layout manager on tab mode after refreshing page ([298fce](https://github.com/OntimizeWeb/ontimize-web-ngx/pull/769/commits/298fce)) Closes [#753](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/753)
 
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/filter-by-column/o-table-filter-by-column-data-dialog.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/filter-by-column/o-table-filter-by-column-data-dialog.component.html
@@ -39,7 +39,7 @@
             {{ record.value || ('TABLE.FILTER_BY_COLUMN.EMPTY_VALUE' | oTranslate) }}
           </ng-container>
           <ng-template *ngIf="column.renderer" [ngTemplateOutlet]="column.renderer.templateref"
-            [ngTemplateOutletContext]="{ cellvalue: record.value, rowvalue: getRowValue(record.tableIndex) }">
+            [ngTemplateOutletContext]="{ cellvalue: record.value, rowvalue: record.rowValue }">
           </ng-template>
         </mat-list-option>
       </mat-selection-list>

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/filter-by-column/o-table-filter-by-column-data-dialog.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/filter-by-column/o-table-filter-by-column-data-dialog.component.ts
@@ -90,6 +90,7 @@ export class OTableFilterByColumnDataDialogComponent implements AfterViewInit {
     let previousFilter: OColumnValueFilter = data.previousFilter || {
       attr: undefined,
       operator: undefined,
+      rowValue: undefined,
       values: undefined,
       availableValues: undefined
     }
@@ -216,6 +217,7 @@ export class OTableFilterByColumnDataDialogComponent implements AfterViewInit {
           this.columnData.push({
             renderedValue: renderedValue,
             value: colValues[i],
+            rowValue: this.tableData[i],
             selected: filter.operator === ColumnValueFilterOperator.IN && (filter.values || []).indexOf(colValues[i]) !== -1,
             // storing the first index where this renderedValue is obtained. In the template of this component the column renderer will obtain the
             // row value of this index
@@ -332,10 +334,6 @@ export class OTableFilterByColumnDataDialogComponent implements AfterViewInit {
 
   isDateType(): boolean {
     return 'date' === this.column.type;
-  }
-
-  getRowValue(i: number): any {
-    return this.tableData[i];
   }
 
   getFixedDimensionClass() {

--- a/projects/ontimize-web-ngx/src/lib/types/table/o-table-filter-by-column-data.type.ts
+++ b/projects/ontimize-web-ngx/src/lib/types/table/o-table-filter-by-column-data.type.ts
@@ -1,6 +1,7 @@
 export type TableFilterByColumnData = {
   value: any;
   selected: boolean;
+  rowValue: any;
   renderedValue?: any;
   tableIndex?: number;
 };


### PR DESCRIPTION
Fixes #777.
Removed getRowValue method  and  the rowValue attribute added in TableFilterByColumnData because the second time modal is opened, table [i] may not exist