### PR TITLE
[8.x.x] Fixed the arrows are not displayed correctly in modal

### DIFF
--- a/projects/ontimize-web-ngx/ontimize.scss
+++ b/projects/ontimize-web-ngx/ontimize.scss
@@ -146,6 +146,10 @@ button {
     height: 32px;
     line-height: 32px;
   }
+
+  &.mat-icon-button {
+    width: 32px;
+  }
 }
 
 .o-table-apply-configuration-dialog-list.mat-selection-list.mat-list-base[dense] .mat-list-option.mat-list-text,
@@ -166,5 +170,5 @@ button {
 }
 
 .overlay-ref-display-none .cdk-overlay-pane.o-context-menu {
-  display:none;
+  display: none;
 }

--- a/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.scss
@@ -1,0 +1,8 @@
+.mat-calendar-controls {
+  .mat-calendar-next-button,
+  .mat-calendar-previous-button {
+    &::after {
+      margin: 11.5px;
+    }
+  }
+}

--- a/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, forwardRef, Inject, Injector, OnDestroy, OnInit, Optional, ViewChild } from '@angular/core';
+import { Component, ElementRef, forwardRef, Inject, Injector, OnDestroy, OnInit, Optional, ViewChild, ViewEncapsulation } from '@angular/core';
 import { MediaChange, MediaObserver } from '@angular/flex-layout';
 import { DateAdapter, MAT_DATE_LOCALE, MatDatepicker, MatDatepickerInput, MatDatepickerInputEvent } from '@angular/material';
 import { MomentDateAdapter } from '@angular/material-moment-adapter';
@@ -45,6 +45,7 @@ export const DEFAULT_INPUTS_O_DATE_INPUT = [
   styleUrls: ['./o-date-input.component.scss'],
   outputs: DEFAULT_OUTPUTS_O_DATE_INPUT,
   inputs: DEFAULT_INPUTS_O_DATE_INPUT,
+  encapsulation: ViewEncapsulation.None,
   providers: [
     { provide: DateAdapter, useClass: OntimizeMomentDateAdapter, deps: [MAT_DATE_LOCALE] }
   ]


### PR DESCRIPTION
- Modified the css properties to the new width  of the **mat-icon-button** with 32px instead of 40px
- Updated .mat-calendar-next-button,  .mat-calendar-previous-button classes