### PR TITLE
[8.5.3] Event for static-data

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.ts
@@ -229,9 +229,6 @@ export class OGridComponent extends AbstractOServiceComponent<OGridComponentStat
   public initialize(): void {
     super.initialize();
 
-    if (this.staticData && this.staticData.length) {
-      this.dataResponseArray = this.staticData;
-    }
     if (!Util.isDefined(this.quickFilterColumns)) {
       this.quickFilterColumns = this.columns;
     }
@@ -364,10 +361,10 @@ export class OGridComponent extends AbstractOServiceComponent<OGridComponentStat
   public ngOnChanges(changes: { [propName: string]: SimpleChange }): void {
     if (changes.staticData !== undefined) {
       this.dataResponseArray = changes.staticData.currentValue;
+      this.onDataLoaded.emit(this.dataResponseArray);
       this.filterData();
     }
   }
-
   public destroy(): void {
     super.destroy();
     if (this.subscription) {

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.ts
@@ -171,6 +171,7 @@ export class OListComponent extends AbstractOServiceComponent<OListComponentStat
   public ngOnChanges(changes: { [propName: string]: SimpleChange }): void {
     if (changes.staticData !== undefined) {
       this.dataResponseArray = changes.staticData.currentValue;
+      this.onDataLoaded.emit(this.dataResponseArray);
       this.filterData();
     }
   }
@@ -181,10 +182,6 @@ export class OListComponent extends AbstractOServiceComponent<OListComponentStat
 
   public initialize(): void {
     super.initialize();
-
-    if (this.staticData && this.staticData.length) {
-      this.dataResponseArray = this.staticData;
-    }
     if (!Util.isDefined(this.quickFilterColumns)) {
       this.quickFilterColumns = this.columns;
     }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -2428,8 +2428,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       this.staticData = data;
       this.daoTable.usingStaticData = true;
       this.daoTable.setDataArray(this.staticData);
-
-
+      this.onDataLoaded.emit(this.daoTable.data);
     }
   }
 


### PR DESCRIPTION
- Emit **onDataLoaded** event in o-table, o-grid and o-list component when load static data
- The following code was eliminated in the o-grid and o-list component because it is already in super.initialize (); and ngOnChanges is thrown twice
 ```
  if (this.staticData && this.staticData.length) {
      this.dataResponseArray = this.staticData;
    }
```