### PR TITLE
[8.x.x] fixed working of query-rows in o-list component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.5.5
+### Bug fixes
+  * **o-list**: Deleted code where the value of query-rows stored in localStorage is checked because this value is not stored ([74af8920](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/74af8920)) Closes [#847](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/847)
+
 ## 8.5.4 (2021-11-05)
 ### Bug fixes
   * **o-combo**: added new atribute `null-selection-label` to add a text to none selection in a combo ([99c2cf70](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/99c2cf70)) Closes [#812](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/812)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 8.5.5
 ### Bug fixes
-  * **o-list**: Deleted code where the value of query-rows stored in localStorage is checked because this value is not stored ([74af8920](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/74af8920)) Closes [#847](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/847)
+  * **o-list**: Fixed issue preventing query-rows from working properly ([74af8920](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/74af8920)) Closes [#847](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/847)
 
 ## 8.5.4 (2021-11-05)
 ### Bug fixes

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.ts
@@ -190,9 +190,6 @@ export class OListComponent extends AbstractOServiceComponent<OListComponentStat
     if (!Util.isDefined(this.state.totalQueryRecordsNumber)) {
       this.state.totalQueryRecordsNumber = 0;
     }
-    if (Util.isDefined(this.state.queryRows)) {
-      this.queryRows = this.state.queryRows;
-    }
   }
 
   public reinitialize(options: OListInitializationOptions): void {


### PR DESCRIPTION
Deleted code where the value of query-rows stored in localStorage is checked because this value is not stored. Closes #847 