### PR TITLE
[8.x.x] o-form: Close insert form without confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 * **o-combo**: Fixed that the height is larger than other input component ([b8bbe88](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b8bbe88)) Closes [#924](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/924)
 * Solve security hotspots reported by Sonar ([e313003](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e313003)) Closes [#923](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/923)
+* **o-form**: Fixed that the method `closeDetail` showing the confirm message when the attribute `confirm-exit="no"`([482fb60](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/482fb60))([1d236a0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1d236a0))([e6c18ba](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e6c18ba)) Closes [#595](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/595)
 
 ## 8.5.10 (2022-03-21)
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Solve security hotspots reported by Sonar ([e313003](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e313003)) Closes [#923](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/923)
 * **o-form**: Fixed that the method `closeDetail` showing the confirm message when the attribute `confirm-exit="no"`([482fb60](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/482fb60))([1d236a0](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1d236a0))([e6c18ba](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e6c18ba)) Closes [#595](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/595)
 
+### BREAKING CHANGES
+* **o-form**: now the method `goEditMode` has not argument
+
+
 ## 8.5.10 (2022-03-21)
 ### Feature
   * **app-menu-config**: new `pathMatch` attribute in `MenuItemRoute` ([c51fb374](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c51fb374)) Closes [#919](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/919)

--- a/projects/ontimize-web-ngx/src/lib/components/form/cache/o-form.cache.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/cache/o-form.cache.class.ts
@@ -121,7 +121,7 @@ export class OFormCacheClass {
     this.initializeCache(this.getDataCache());
   }
 
-  undoLastChange(options: any = {}) {
+  undoLastChange() {
     const lastElement = this.valueChangesStack[this.valueChangesStack.length - 1];
     if (lastElement) {
       const lastCacheValue = this.getCacheLastValue(lastElement.attr);

--- a/projects/ontimize-web-ngx/src/lib/components/form/cache/o-form.cache.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/cache/o-form.cache.class.ts
@@ -204,7 +204,19 @@ export class OFormCacheClass {
     }
 
     let initialKeys = Object.keys(initialCache);
-    const currentKeys = currentCache ? Object.keys(currentCache) : initialKeys;
+    let currentKeys = currentCache ? Object.keys(currentCache) : initialKeys;
+
+    // Remove ignored fields from temporary initial cache data
+    if (ignoreAttrs.length) {
+      initialKeys = initialKeys.filter(key => !ignoreAttrs.includes(key));
+      currentKeys = currentKeys.filter(key => !ignoreAttrs.includes(key));
+      ignoreAttrs.forEach(key => delete initialCache[key]);
+    }
+
+    if (currentKeys.length === 0) {
+      return false;
+    }
+
     if (initialKeys.length !== currentKeys.length) {
       return true;
     }

--- a/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form-confirm-exit.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form-confirm-exit.service.ts
@@ -15,7 +15,7 @@ export class OFormConfirmExitService {
 
   subscribeToDiscardChanges(form: OFormComponent, ignoreAttrs: string[] = []): Promise<boolean> {
     let subscription: Promise<boolean>;
-    if (form.isInitialStateChanged(ignoreAttrs) && !form.isInInitialMode()) {
+    if (form.isInitialStateChanged(ignoreAttrs) && this.mustShowConfirmationInForm(form)) {
       subscription = this.getConfirmDialogSubscription();
     } else {
       const observable = new Observable<boolean>(observer => {
@@ -25,6 +25,10 @@ export class OFormConfirmExitService {
       subscription = observable.toPromise();
     }
     return subscription;
+  }
+
+  protected mustShowConfirmationInForm(form: OFormComponent): boolean {
+    return form.isInInsertMode() || form.isInUpdateMode();
   }
 
   protected restart() {

--- a/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form-confirm-exit.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form-confirm-exit.service.ts
@@ -15,7 +15,7 @@ export class OFormConfirmExitService {
 
   subscribeToDiscardChanges(form: OFormComponent, ignoreAttrs: string[] = []): Promise<boolean> {
     let subscription: Promise<boolean>;
-    if (form.isInitialStateChanged(ignoreAttrs) && !form.isInInsertMode()) {
+    if (form.isInitialStateChanged(ignoreAttrs) && !form.isInInitialMode()) {
       subscription = this.getConfirmDialogSubscription();
     } else {
       const observable = new Observable<boolean>(observer => {
@@ -30,7 +30,7 @@ export class OFormConfirmExitService {
   protected restart() {
     this.confirmDialogSubscription = null;
   }
-  
+
   protected getConfirmDialogSubscription(): Promise<boolean> {
     if (!Util.isDefined(this.confirmDialogSubscription)) {
       this.confirmDialogSubscription = new Promise((resolve) => {

--- a/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
@@ -166,7 +166,7 @@ export class OFormNavigationClass {
     }
     this.cacheStateSubscription = formCache.onCacheStateChanges.subscribe(() => {
       const initialStateChanged = this.form.isInitialStateChanged();
-      const triggerExitConfirm = this.form.isInitialStateChanged(this.form.ignoreOnExit);
+      const triggerExitConfirm = this.form.confirmExit ? this.form.isInitialStateChanged(this.form.ignoreOnExit) : this.form.confirmExit;
       this.setModifiedState(initialStateChanged, triggerExitConfirm);
     });
   }

--- a/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
@@ -166,7 +166,7 @@ export class OFormNavigationClass {
     }
     this.cacheStateSubscription = formCache.onCacheStateChanges.subscribe(() => {
       const initialStateChanged = this.form.isInitialStateChanged();
-      const triggerExitConfirm = this.form.confirmExit ? this.form.isInitialStateChanged(this.form.ignoreOnExit) : this.form.confirmExit;
+      const triggerExitConfirm = this.form.confirmExit && this.form.isInitialStateChanged(this.form.ignoreOnExit);
       this.setModifiedState(initialStateChanged, triggerExitConfirm);
     });
   }

--- a/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/navigation/o-form.navigation.class.ts
@@ -314,7 +314,7 @@ export class OFormNavigationClass {
         this.navigationService.removeLastItem();
       }
       let params: any[] = [];
-      this.form.keysArray.forEach((current, index) => {
+      this.form.keysArray.forEach((current) => {
         if (insertedKeys[current]) {
           params.push(insertedKeys[current]);
         }

--- a/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
@@ -572,7 +572,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
       case Codes.RELOAD_ACTION: this.reload(true); break;
       case Codes.GO_INSERT_ACTION: this.goInsertMode(options); break;
       case Codes.INSERT_ACTION: this.insert(); break;
-      case Codes.GO_EDIT_ACTION: this.goEditMode(options); break;
+      case Codes.GO_EDIT_ACTION: this.goEditMode(); break;
       case Codes.EDIT_ACTION: this.update(); break;
       case Codes.UNDO_LAST_CHANGE_ACTION: this.undo(); break;
       case Codes.DELETE_ACTION: return this.delete();
@@ -962,17 +962,17 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
 
   /**
    * Navigates to 'edit' mode
-   * @deprecated Use `goEditMode(options?: any)` instead
+   * @deprecated Use `goEditMode()` instead
    */
-  _goEditMode(options?: any) {
+  _goEditMode() {
     console.warn('Method `OFormComponent._goEditMode` is deprecated and will be removed in the furute. Use `goEditMode` instead');
-    this.goEditMode(options);
+    this.goEditMode();
   }
 
   /**
    * Navigates to 'edit' mode
    */
-  goEditMode(options?: any) {
+  goEditMode() {
     this.formNavigation.goEditMode();
   }
 
@@ -1575,7 +1575,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
   getFieldReferences(attrs: string[]): IFormDataComponentHash {
     const arr: IFormDataComponentHash = {};
     const self = this;
-    attrs.forEach((key, index) => {
+    attrs.forEach((key) => {
       arr[key] = self.getFieldReference(key);
     });
     return arr;

--- a/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/form/o-form.component.ts
@@ -1446,9 +1446,7 @@ export class OFormComponent implements OnInit, OnDestroy, CanComponentDeactivate
   }
 
   undoKeyboardPressed() {
-    this.formCache.undoLastChange({
-      keyboardEvent: true
-    });
+    this.formCache.undoLastChange();
   }
 
   getFormToolbar(): OFormToolbarComponent {


### PR DESCRIPTION
Fixes #595 
1. The method **_subscribeToDiscardChanges_** allow to show confirm dialog if it is insert form
2. Updated **_isInitialStateChanged_** method, the ignore-exit attributes are removed on `currentKeys` array
3.  Resolved code smell by Sonar

Tested

> 1. Close tab, modal with form layout manager
> 2. Change URL
> 3. Call closeDetail method