### PR TITLE
[8.x.x] o-filter-builder: launches as many queries as there are combos 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 ### Bug fixes
 * **o-combo**: Fixed that the height is larger than other input component ([b8bbe88](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b8bbe88)) Closes [#924](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/924)
 * Solve security hotspots reported by Sonar ([e313003](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e313003)) Closes [#923](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/923)
-* **o-real-input, o-percent-input**: Fixing decimal digits validation problem ([8f10f064]](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/8f10f064])) Closes [#925](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/925)
+* **o-real-input, o-percent-input**: Fixing decimal digits validation problem ([8f10f064](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/8f10f064)) Closes [#925](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/925)
+* **o-filter-build**:
+  * Fixed that launches as many queries as there are combos and `query-on-change = "yes"`([3050498](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/3050498])) Closes [#788](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/788)
+  * new attribute `query-on-change-event-type` ([b779d94](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b779d94]))
 
+### BREAKING CHANGES
+* **o-filter-build**: now when `query-on-change = "yes"` the filter query is fired when the form components fire the event `OnValueChanged` instead of `onChange` ([b779d94](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b779d94]))
 ## 8.5.10 (2022-03-21)
 ### Feature
   * **app-menu-config**: new `pathMatch` attribute in `MenuItemRoute` ([c51fb374](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c51fb374)) Closes [#919](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/919)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes
 * **o-combo**: Fixed that the height is larger than other input component ([b8bbe88](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b8bbe88)) Closes [#924](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/924)
 * Solve security hotspots reported by Sonar ([e313003](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e313003)) Closes [#923](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/923)
+* **o-real-input, o-percent-input**: Fixing decimal digits validation problem ([8f10f064]](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/8f10f064])) Closes [#925](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/925)
 
 ## 8.5.10 (2022-03-21)
 ### Feature

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   * new attribute `query-on-change-event-type` ([b779d94](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b779d94]))
 
 ### BREAKING CHANGES
-* **o-filter-build**: now when `query-on-change = "yes"` the filter query is fired when the form components fire the event `OnValueChanged` instead of `onChange` ([b779d94](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b779d94]))
+* **o-filter-build**: now when `query-on-change = "yes"` the filter query is fired when the form components fire the event `OnValueChanged` instead of `onChange` since with the onChange event unwanted queries were launched ([b779d94](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/b779d94]))
 ## 8.5.10 (2022-03-21)
 ### Feature
   * **app-menu-config**: new `pathMatch` attribute in `MenuItemRoute` ([c51fb374](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/c51fb374)) Closes [#919](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/919)

--- a/projects/ontimize-web-ngx/src/lib/components/filter-builder/o-filter-builder.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/filter-builder/o-filter-builder.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, EventEmitter, forwardRef, Inject, Injector, OnDestroy, OnInit } from '@angular/core';
+import { AfterViewInit, Component, EventEmitter, forwardRef, Inject, OnDestroy, OnInit } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 
@@ -113,9 +113,7 @@ export class OFilterBuilderComponent implements AfterViewInit, OnDestroy, OnInit
           this.subscriptions.add(
             this.getEventFromFormComponent(formComponent)
               .pipe(debounceTime(this.queryOnChangeDelay))
-              .subscribe(a => {
-                this.triggerReload();
-              }));
+              .subscribe(() => this.triggerReload()));
         }
       });
     }

--- a/projects/ontimize-web-ngx/src/lib/components/filter-builder/o-filter-builder.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/filter-builder/o-filter-builder.component.ts
@@ -30,7 +30,7 @@ export const DEFAULT_INPUTS_O_FILTER_BUILDER = [
   'queryOnChangeDelay: query-on-change-delay',
 
   //query-on-change-event: [change| onValueChange] Type of event that emit when query-on-change=`yes`
-  'queryOnChangeEventType: query-on-change-event-type '
+  'queryOnChangeEventType: query-on-change-event-type'
 ]
 
 export const DEFAULT_OUTPUTS_O_FILTER_BUILDER = [

--- a/projects/ontimize-web-ngx/src/lib/components/input/combo/o-combo.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/input/combo/o-combo.component.ts
@@ -296,7 +296,7 @@ export class OComboComponent extends OFormServiceComponent implements OnInit, Af
       if (this._fControl && readOnly) {
         this._fControl.disable();
       } else if (this._fControl) {
-        this._fControl.enable();
+        this._fControl.enable({ emitEvent: false });
       }
     }
   }

--- a/projects/ontimize-web-ngx/src/lib/components/input/combo/o-combo.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/input/combo/o-combo.component.ts
@@ -294,7 +294,7 @@ export class OComboComponent extends OFormServiceComponent implements OnInit, Af
     const readOnly = Util.isDefined(this.readOnly) ? this.readOnly : value;
     if (this.enabled) {
       if (this._fControl && readOnly) {
-        this._fControl.disable();
+        this._fControl.disable({ emitEvent: false });
       } else if (this._fControl) {
         this._fControl.enable({ emitEvent: false });
       }

--- a/projects/ontimize-web-ngx/src/lib/components/input/real-input/o-real-input.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/input/real-input/o-real-input.component.ts
@@ -3,9 +3,14 @@ import { FormControl, ValidationErrors, ValidatorFn } from '@angular/forms';
 
 import { InputConverter } from '../../../decorators/input-converter';
 import { IRealPipeArgument, ORealPipe } from '../../../pipes/o-real.pipe';
+import { NumberService } from '../../../services/number.service';
 import { Util } from '../../../util/util';
 import { OFormComponent } from '../../form/o-form.component';
-import { DEFAULT_INPUTS_O_INTEGER_INPUT, DEFAULT_OUTPUTS_O_INTEGER_INPUT, OIntegerInputComponent } from '../integer-input/o-integer-input.component';
+import {
+  DEFAULT_INPUTS_O_INTEGER_INPUT,
+  DEFAULT_OUTPUTS_O_INTEGER_INPUT,
+  OIntegerInputComponent
+} from '../integer-input/o-integer-input.component';
 
 export const DEFAULT_INPUTS_O_REAL_INPUT = [
   ...DEFAULT_INPUTS_O_INTEGER_INPUT,
@@ -42,6 +47,7 @@ export class ORealInputComponent extends OIntegerInputComponent implements OnIni
 
   protected decimalSeparator: string;
   protected pipeArguments: IRealPipeArgument;
+  protected numberService: NumberService;
 
   constructor(
     @Optional() @Inject(forwardRef(() => OFormComponent)) form: OFormComponent,
@@ -50,6 +56,7 @@ export class ORealInputComponent extends OIntegerInputComponent implements OnIni
   ) {
     super(form, elRef, injector);
     this._defaultSQLTypeKey = 'FLOAT';
+    this.numberService = this.injector.get(NumberService);
   }
 
   setComponentPipe(): void {
@@ -62,6 +69,9 @@ export class ORealInputComponent extends OIntegerInputComponent implements OnIni
     this.pipeArguments.minDecimalDigits = this.minDecimalDigits;
     this.pipeArguments.maxDecimalDigits = this.maxDecimalDigits;
     this.pipeArguments.truncate = false;
+    if (!this.isEmpty()) {
+      this.ensureOFormValue(this.value);
+    }
   }
 
   resolveValidators(): ValidatorFn[] {
@@ -70,6 +80,16 @@ export class ORealInputComponent extends OIntegerInputComponent implements OnIni
       validators.push(this.maxDecimalDigitsValidator.bind(this));
     }
     return validators;
+  }
+
+  ensureOFormValue(arg: any): void {
+    super.ensureOFormValue(arg);
+    if (!this.isEmpty() && Util.isDefined(this.pipeArguments)) {
+      this.value.value = this.numberService.getRealValue(this.value.value, this.pipeArguments);
+      if (Util.isDefined(this._fControl)) {
+        this._fControl.setValue(this.value.value, { emitEvent: false, emitModelToViewChange: false });
+      }
+    }
   }
 
   protected maxDecimalDigitsValidator(control: FormControl): ValidationErrors {

--- a/projects/ontimize-web-ngx/src/lib/util/codes.ts
+++ b/projects/ontimize-web-ngx/src/lib/util/codes.ts
@@ -1,5 +1,7 @@
 export type OAppLayoutMode = 'mobile' | 'desktop';
 export type OSidenavMode = 'over' | 'push' | 'side';
+export type CHANGE_EVENTS = 'onValueChange' | 'onChange';
+
 export class Codes {
 
   public static PAGINATED_QUERY_METHOD = 'advancedQuery';
@@ -117,6 +119,7 @@ export class Codes {
   public static APP_LAYOUT_MODE_DESKTOP: OAppLayoutMode = 'desktop';
   public static APP_LAYOUT_MODE_MOBILE: OAppLayoutMode = 'mobile';
 
+  public static DEFAULT_CHANGE_EVENT: CHANGE_EVENTS = 'onValueChange';
 
   static isDoubleClickMode(value: string): boolean {
     return Codes.DETAIL_MODE_DBLCLICK_VALUES.indexOf(value) !== -1;


### PR DESCRIPTION
1. Fixes #788 
2. Avoid emitting the valueChanges event in the setIsReadOnly method
3. New attribute `query-on-change-event-type `in `o-filter-builder` component