### PR TITLE
[8.x.x] o-password-input:  Bugs with show-password-button

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/input/input.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/input/input.scss
@@ -7,8 +7,8 @@ div.icon-btn {
   }
 }
 
-$suffix-size: 24;
-$width24: $suffix-size * 1px;
+$suffix-size: 20px;
+$width24: 24px;
 
 .o-tooltip.mat-tooltip {
   &.after,
@@ -68,16 +68,14 @@ $width24: $suffix-size * 1px;
         display: inherit;
 
         .mat-icon {
-          width: 20px;
-          height: 20px;
-          line-height: 20px;
+          height: $suffix-size;
+          line-height: $suffix-size;
         }
 
         .mat-icon-button {
-          line-height: $width24;
+          line-height: $suffix-size;
           display: block;
-          width: $width24;
-          height: $width24;
+          height: $suffix-size;
         }
       }
     }
@@ -107,8 +105,7 @@ $width24: $suffix-size * 1px;
       .icon-btn,
       .mat-icon-button,
       .mat-icon:not([svgicon]) {
-        width: $width24;
-        height: $width24;
+        height: $suffix-size;
       }
 
       .svg-icon > svg {

--- a/projects/ontimize-web-ngx/src/lib/components/input/password-input/o-password-input.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/input/password-input/o-password-input.component.html
@@ -5,7 +5,7 @@
     <mat-label *ngIf="labelVisible">{{ olabel | oTranslate }}</mat-label>
     <input matInput [type]="hide ? 'password' : 'text'" [id]="getAttribute()" [formControlName]="getAttribute()" [placeholder]="placeHolder"
       (focus)="innerOnFocus($event)" (blur)="innerOnBlur($event)" (change)="onChangeEvent($event)" [readonly]="isReadOnly" [required]="isRequired">
-    <mat-icon *ngIf='showPasswordButton' matSuffix (click)="hide = !hide">{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+    <mat-icon *ngIf='showPasswordButton && !isReadOnly && enabled' matSuffix (click)="hide = !hide">{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
     <button type="button" *ngIf="showClearButton" matSuffix mat-icon-button (click)="onClickClearValue($event)">
       <mat-icon svgIcon="ontimize:close"></mat-icon>
     </button>


### PR DESCRIPTION
- Updated classes when mat-icon is added as matPrefix or matSuffix
- Hide button when the component has set `read-only='yes'` and `enabled='yes'`