### PR TITLE
[8.x.x] o-table-cell-editor-date and o-table-cell-editor-time: the arrow icons dont show in date popup

### DIFF
--- a/projects/ontimize-web-ngx/ontimize.scss
+++ b/projects/ontimize-web-ngx/ontimize.scss
@@ -5,6 +5,7 @@
 
 $mat-button-line-height: 32px;
 $mat-menu-item-height: 32px;
+$mat-calendar-prev-next-icon-margin: 11.5px;
 $mat-stroked-button-line-height: $mat-button-line-height - 2;
 
 .relative {
@@ -179,4 +180,14 @@ button {
 
 .overlay-ref-display-none .cdk-overlay-pane.o-context-menu {
   display: none;
+}
+
+/* DATE PICKER */
+.mat-calendar-controls {
+  button.mat-calendar-next-button,
+  button.mat-calendar-previous-button {
+    &::after {
+      margin: $mat-calendar-prev-next-icon-margin;
+    }
+  }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/container/o-container-collapsible.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/container/o-container-collapsible.component.scss
@@ -45,7 +45,7 @@
         }
 
         .mat-expansion-indicator::after {
-          transform: rotate(45deg)translateY(-2px)translateX(-2px);
+          transform: rotate(45deg) translateY(-2px) translateX(-2px);
         }
       }
 

--- a/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.scss
@@ -1,8 +1,0 @@
-.mat-calendar-controls {
-  .mat-calendar-next-button,
-  .mat-calendar-previous-button {
-    &::after {
-      margin: 11.5px;
-    }
-  }
-}

--- a/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/input/date-input/o-date-input.component.ts
@@ -54,7 +54,6 @@ export const DEFAULT_INPUTS_O_DATE_INPUT = [
 @Component({
   selector: 'o-date-input',
   templateUrl: './o-date-input.component.html',
-  styleUrls: ['./o-date-input.component.scss'],
   outputs: DEFAULT_OUTPUTS_O_DATE_INPUT,
   inputs: DEFAULT_INPUTS_O_DATE_INPUT,
   encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
Fixes #949, moved css styles from o-date-input to ontimize.scss because it's common code.
Fixes css error 