### PR TITLE
[8.x.x] Tooltip errors are not displayed in modals that extend OTableBaseDialogClass

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/index.ts
@@ -6,3 +6,4 @@ export * from './store-configuration/o-table-store-configuration-dialog.componen
 export * from './store-filter/o-table-store-filter-dialog.component';
 export * from './visible-columns/o-table-visible-columns-dialog.component';
 export * from './group-by-columns/o-table-group-by-columns-dialog.component';
+export * from './o-table-base-dialog.class';

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/o-table-base-dialog.class.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/o-table-base-dialog.class.ts
@@ -52,4 +52,8 @@ export class OTableBaseDialogClass {
   protected formControlHasErrors(): boolean {
     return Util.isDefined(this.formControl) && this.formControl.touched && Util.isDefined(this.formControl.errors);
   }
+
+  public hasError(fControl: AbstractControl, error: string): boolean {
+    return fControl && fControl.touched && fControl.hasError(error);
+  }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/store-configuration/o-table-store-configuration-dialog.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/store-configuration/o-table-store-configuration-dialog.component.html
@@ -5,8 +5,8 @@
   <form #form [formGroup]="formGroup" fxLayout="column">
     <mat-form-field>
       <input matInput [matTooltip]="tooltipText" [matTooltipClass]="tooltipClass" placeholder="{{ 'TABLE.DIALOG.CONFIGURATION_NAME' | oTranslate }}"
-        formControlName="name" required>
-      <mat-error *oMatError="formGroup.controls['name'].hasError('required')">
+        formControlName="name" required />
+      <mat-error *oMatError="hasError(formGroup.controls['name'], 'required')">
         {{ 'FORM_VALIDATION.REQUIRED' | oTranslate }}
       </mat-error>
     </mat-form-field>

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/store-filter/o-table-store-filter-dialog.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/dialog/store-filter/o-table-store-filter-dialog.component.html
@@ -6,10 +6,10 @@
     <mat-form-field>
       <input matInput [matTooltip]="tooltipText" [matTooltipClass]="tooltipClass" placeholder="{{ 'TABLE.DIALOG.FILTER_NAME' | oTranslate }}"
         formControlName="name" required>
-      <mat-error *oMatError="formGroup.controls['name'].hasError('filterNameAlreadyExists')">
+      <mat-error *oMatError="hasError(formGroup.controls['name'], 'filterNameAlreadyExists')">
         {{ 'TABLE.DIALOG.FILTER_NAME_ALREADY_EXISTS' | oTranslate }}
       </mat-error>
-      <mat-error *oMatError="formGroup.controls['name'].hasError('required')">
+      <mat-error *oMatError="hasError(formGroup.controls['name'], 'required')">
         {{ 'FORM_VALIDATION.REQUIRED' | oTranslate }}
       </mat-error>
     </mat-form-field>


### PR DESCRIPTION
- Export OTableBaseDialogClass
- Added new method hasError in OTableBaseDialogClass
- Updated oMatError condition