### PR TITLE
[8.x.x] o-table: set `auto-adjust` input to true by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
-## 8.7.3
+## 8.7.3 (2022-10-06)
+### Features
+* **o-table**: New `O_TABLE_GLOBAL_CONFIG` InjectionToken ([73e9be8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/73e9be8))
+### BREAKING CHANGES
+* **o-table**: Set `auto-adjust=true` by default ([47e252e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/47e252e)) Closes [#1045](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1045)
+
+To resolve this breaking change, you can use the new `O_TABLE_GLOBAL_CONFIG` InjectionToken as follows
+
+```ts
+@NgModule({
+  declarations: [
+  ...
+  ],
+  ...
+  providers: [
+    ...
+    { provide: O_TABLE_GLOBAL_CONFIG, useValue: { autoAdjust: false } },
+    ...
+  ],
+  ...
+})
+```
 
 ## 8.7.2 (2022-09-15)
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 8.7.3 (2022-10-06)
 ### Features
 * **o-table**: New `O_TABLE_GLOBAL_CONFIG` InjectionToken ([73e9be8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/73e9be8))
+
 ### BREAKING CHANGES
 * **o-table**: Set `auto-adjust=true` by default ([47e252e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/47e252e)) Closes [#1045](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1045)
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/index.ts
@@ -2,3 +2,4 @@ export * from './column/index';
 export * from './extensions/index';
 export * from './o-table.component';
 export * from './o-table.module';
+export * from './utils/o-table.tokens';

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -21,6 +21,7 @@ import {
   OnInit,
   Optional,
   QueryList,
+  SimpleChange,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -56,6 +57,7 @@ import { OColumnAggregate } from '../../types/table/o-column-aggregate.type';
 import { ColumnValueFilterOperator, OColumnValueFilter } from '../../types/table/o-column-value-filter.type';
 import { TableFilterByColumnDialogResult } from '../../types/table/o-table-filter-by-column-data.type';
 import { OTableFiltersStatus } from '../../types/table/o-table-filter-status.type';
+import { OTableGlobalConfig } from '../../types/table/o-table-global-config.type';
 import { OTableInitializationOptions } from '../../types/table/o-table-initialization-options.type';
 import { OTableMenuPermissions } from '../../types/table/o-table-menu-permissions.type';
 import { OTablePermissions } from '../../types/table/o-table-permissions.type';
@@ -101,6 +103,7 @@ import {
 } from './extensions/row/table-row-expandable/o-table-row-expandable.component';
 import { OMatSort } from './extensions/sort/o-mat-sort';
 import { OMatSortHeader } from './extensions/sort/o-mat-sort-header';
+import { O_TABLE_GLOBAL_CONFIG } from './utils/o-table.tokens';
 
 
 export const DEFAULT_INPUTS_O_TABLE = [
@@ -283,6 +286,8 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   @ViewChild(OMatSort, { static: false }) sort: OMatSort;
 
   public virtualScrollViewport: CdkVirtualScrollViewport;
+
+  public oTableGlobalConfig: OTableGlobalConfig;
   @ViewChild('virtualScrollViewPort', { static: false }) set cdkVirtualScrollViewport(value: CdkVirtualScrollViewport) {
     if (value != this.virtualScrollViewport) {
       this.virtualScrollViewport = value;
@@ -417,8 +422,18 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   orderable: boolean = true;
   @InputConverter()
   resizable: boolean = true;
+  private _autoAdjust: boolean;
   @InputConverter()
-  autoAdjust: boolean = true;
+  set autoAdjust(value: boolean) {
+    this._autoAdjust = BooleanConverter(value);
+  }
+  get autoAdjust(): boolean {
+    if (!Util.isDefined(this._autoAdjust) && Util.isDefined(this.oTableGlobalConfig)) {
+      return this.oTableGlobalConfig.autoAdjust;
+    }
+    return this._autoAdjust;
+  }
+
   @InputConverter()
   groupable: boolean = true;
   @InputConverter()
@@ -670,8 +685,13 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }
 
     this.snackBarService = this.injector.get(SnackBarService);
-  }
+    try {
+      this.oTableGlobalConfig = this.injector.get(O_TABLE_GLOBAL_CONFIG);
 
+    } catch (error) {
+      // Do nothing because is optional
+    }
+  }
   get state(): OTableComponentStateClass {
     return this.componentStateService.state;
   }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -424,7 +424,6 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   resizable: boolean = true;
   @InputConverter()
   autoAdjust: boolean = true;
-
   @InputConverter()
   groupable: boolean = true;
   @InputConverter()

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -418,7 +418,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   @InputConverter()
   resizable: boolean = true;
   @InputConverter()
-  autoAdjust: boolean = false;
+  autoAdjust: boolean = true;
   @InputConverter()
   groupable: boolean = true;
   @InputConverter()

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -21,6 +21,7 @@ import {
   OnInit,
   Optional,
   QueryList,
+  SimpleChange,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -186,7 +187,7 @@ export const DEFAULT_INPUTS_O_TABLE = [
   // exportServiceType [ string ]: The service used by the table for exporting it's data, it must implement 'IExportService' interface. Default: 'OntimizeExportService'
   'exportServiceType: export-service-type',
 
-  // auto-adjust [true|false]: Auto adjust column width to fit its content. Default: false
+  // auto-adjust [true|false]: Auto adjust column width to fit its content. Default: true
   'autoAdjust: auto-adjust',
 
   // show-filter-option [yes|no|true|false]: show filter menu option in the header menu. Default: yes.
@@ -421,17 +422,8 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   orderable: boolean = true;
   @InputConverter()
   resizable: boolean = true;
-  private _autoAdjust: boolean;
   @InputConverter()
-  set autoAdjust(value: boolean) {
-    this._autoAdjust = BooleanConverter(value);
-  }
-  get autoAdjust(): boolean {
-    if (!Util.isDefined(this._autoAdjust) && Util.isDefined(this.oTableGlobalConfig)) {
-      return this.oTableGlobalConfig.autoAdjust;
-    }
-    return this._autoAdjust;
-  }
+  autoAdjust: boolean = true;
 
   @InputConverter()
   groupable: boolean = true;
@@ -684,13 +676,18 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }
 
     this.snackBarService = this.injector.get(SnackBarService);
+    this.getGlobalConfig();
+  }
+
+  private getGlobalConfig() {
     try {
       this.oTableGlobalConfig = this.injector.get(O_TABLE_GLOBAL_CONFIG);
-
+      this.autoAdjust = this.oTableGlobalConfig.autoAdjust;
     } catch (error) {
       // Do nothing because is optional
     }
   }
+
   get state(): OTableComponentStateClass {
     return this.componentStateService.state;
   }
@@ -719,6 +716,12 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
 
   ngAfterViewChecked() {
     this.cd.detectChanges();
+  }
+
+  ngOnChanges(changes: { [propName: string]: SimpleChange }): void {
+    if (Util.isDefined(changes.autoAdjust) && changes.autoAdjust.currentValue !== changes.autoAdjust.previousValue) {
+      this.autoAdjust = changes.autoAdjust.currentValue;
+    }
   }
 
   updateHeaderAndFooterStickyPositions() {

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -21,7 +21,6 @@ import {
   OnInit,
   Optional,
   QueryList,
-  SimpleChange,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -1106,26 +1105,24 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       // in this case you have to add this column to this.visibleColArray
       const colToAddInVisibleCol = Util.differenceArrays(visibleColArray, originalVisibleColArray);
       if (colToAddInVisibleCol.length > 0) {
-        colToAddInVisibleCol.forEach((colAdd, index) => {
+        colToAddInVisibleCol.forEach((colAdd) => {
           if (stateCols.filter(col => col.attr === colAdd).length > 0) {
-            stateCols = stateCols.map(col => {
-              if (colToAddInVisibleCol.indexOf(col.attr) > -1) {
+            stateCols = stateCols.filter(col => colToAddInVisibleCol.indexOf(col.attr) > -1)
+              .map(col => {
                 col.visible = true;
-              }
-              return col;
-            });
+                return col;
+              });
           } else {
-            this.colArray.forEach((element, i) => {
-              if (element === colAdd) {
+            this.colArray.filter(col => col === colAdd)
+              .forEach((element, i) => {
                 stateCols.splice(i + 1, 0,
                   {
                     attr: colAdd,
                     visible: true,
                     width: undefined
                   });
-              }
 
-            });
+              });
           }
         });
       }
@@ -1134,10 +1131,8 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       // in this case you have to delete this column to this.visibleColArray
       const colToDeleteInVisibleCol = Util.differenceArrays(originalVisibleColArray, visibleColArray);
       if (colToDeleteInVisibleCol.length > 0) {
-        stateCols = stateCols.map(col => {
-          if (colToDeleteInVisibleCol.indexOf(col.attr) > -1) {
-            col.visible = false;
-          }
+        stateCols = stateCols.filter(col => colToDeleteInVisibleCol.indexOf(col.attr) > -1).map(col => {
+          col.visible = false;
           return col;
         });
       }

--- a/projects/ontimize-web-ngx/src/lib/components/table/utils/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './o-table.tokens';

--- a/projects/ontimize-web-ngx/src/lib/components/table/utils/o-table.tokens.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/utils/o-table.tokens.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from "@angular/core";
+import { OTableGlobalConfig } from "../../../types/table/o-table-global-config.type";
+
+export const O_TABLE_GLOBAL_CONFIG = new InjectionToken<OTableGlobalConfig>('o-table-config');

--- a/projects/ontimize-web-ngx/src/lib/types/table/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/types/table/index.ts
@@ -9,3 +9,4 @@ export * from './o-table-filter-status.type';
 export * from './o-table-initialization-options.type';
 export * from './o-table-menu-permissions.type';
 export * from './o-table-permissions.type';
+export * from './o-table-global-config.type';

--- a/projects/ontimize-web-ngx/src/lib/types/table/o-table-global-config.type.ts
+++ b/projects/ontimize-web-ngx/src/lib/types/table/o-table-global-config.type.ts
@@ -1,0 +1,3 @@
+export type OTableGlobalConfig = {
+  autoAdjust: boolean;
+};


### PR DESCRIPTION
1. Set `auto-adjust= true` by default
2. New injectionToken O_TABLE_GLOBAL_CONFIG
3. Fixes #1045 