### PR TITLE
o-list, o-grid, o-table: Allow to add custom content in toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Modified the order of the table menu options ([54dad824](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/54dad824))
   * Added a new menu option to reset the columns width ([f5d1f74a](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/f5d1f74a)) Closes [#799](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/799)
 * **o-grid,o-list**: Moved `quick-filter-appearance` to AbstractOServiceComponent ([0bc6c49](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0bc6c49))
+* **o-table, o-grid, o-list**: Added directive `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar` to add custom content in position start or end of the toolbars ([1778a61](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1778a61)) Closes [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044)
 
 ### Bug fixes
 * **o-real-input**: New attribute `strict` ([e466768f](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e466768f)) ([e264a54](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/e264a54)) Closes [#1022](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1022)
@@ -22,14 +23,14 @@
     * There is a new `oMatError` directive that user must use instead `ngIf` for having the `O_MAT_ERROR_OPTIONS` features available in the Angular Material `mat-error` component. See documentation for more info.
 * **service-type**: Fixes bug when multiple components use the same service-type ([380fda3](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/380fda3)) Closes [#1015](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1015)
 * **o-hour-input**: Fixing wrong `value-type="timestamp"` value saving ([f3d6f39c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/f3d6f39c)) ([5b9abf17](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/5b9abf17)) Closes [#960](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/960)
-* **o-table, o-grid, o-list**: Added directive `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar` ([1778a61](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1778a61)) Closes [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044)
 
 ### BREAKING CHANGES
 * Due to the fix of the issue [#1015](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1015), to set the `service-type` attribute on the component, the provider defined in the module cannot set `useFactory`, instead use `useValue` because Ontimize Web is responsible for creating each instance for this service.
-* Due to the fix of the issue [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044)
-  * Renamed CSS class `table-title` to `title`
-  * Unified the styles of the titles of the `o-table`, `o-list`, `o-grid` with new CSS class to `title`
+* Due to the improvement of the issue [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044) the `o-table`, `o-list`, `o-grid` toolbars have been factored and this causes the following changes.
+  * The css selectors related to the mat-toolbar will stop working in `o-table`, `o-list`, `o-grid` components.
   * New CSS class `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar`
+  * Unified the styles of the titles of the `o-table`, `o-list`, `o-grid` with new CSS class to `title` and therefore removed CSS class `table-title` and `o-list-title`
+
 * **Application configuration file `app.config,ts`**
 
 The default value of `serviceType` has been changed to `OntimizeEE` and the default value of `permissionsServiceType` has been changed to `OntimizeEEPermissions`([25cc5c8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/25cc5c8))  Closes [#967](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/967)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,14 @@
     * There is a new `oMatError` directive that user must use instead `ngIf` for having the `O_MAT_ERROR_OPTIONS` features available in the Angular Material `mat-error` component. See documentation for more info.
 * **service-type**: Fixes bug when multiple components use the same service-type ([380fda3](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/380fda3)) Closes [#1015](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1015)
 * **o-hour-input**: Fixing wrong `value-type="timestamp"` value saving ([f3d6f39c](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/f3d6f39c)) ([5b9abf17](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/5b9abf17)) Closes [#960](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/960)
+* **o-table, o-grid, o-list**: Added directive `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar` ([1778a61](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/1778a61)) Closes [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044)
 
 ### BREAKING CHANGES
 * Due to the fix of the issue [#1015](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1015), to set the `service-type` attribute on the component, the provider defined in the module cannot set `useFactory`, instead use `useValue` because Ontimize Web is responsible for creating each instance for this service.
-
+* Due to the fix of the issue [#1044](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1044)
+  * Renamed CSS class `table-title` to `title`
+  * Unified the styles of the titles of the `o-table`, `o-list`, `o-grid` with new CSS class to `title`
+  * New CSS class `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar`
 * **Application configuration file `app.config,ts`**
 
 The default value of `serviceType` has been changed to `OntimizeEE` and the default value of `permissionsServiceType` has been changed to `OntimizeEEPermissions`([25cc5c8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/25cc5c8))  Closes [#967](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/967)

--- a/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.html
@@ -1,7 +1,8 @@
 <div [style.display]="isVisible()? '' : 'none'" class="o-grid-container" fxLayout="column" fxLayoutAlign="start stretch">
+
   <!--TOOLBAR-->
-  <mat-toolbar *ngIf="hasControls()" class="o-grid-toolbar">
-    <div class="mat-toolbar-tools" fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="8px" fxFill>
+  <o-data-toolbar *ngIf="hasControls()" class="o-grid-toolbar" [title]="title" [show-title]="hasTitle()">
+    <ng-container o-data-toolbar-projection-start>
       <ng-container *ngIf="showButtonsText;else showButtonsWithoutText">
         <!-- button new-->
         <button *ngIf="insertButton && !insertButtonFloatable" type="button" class="o-grid-add-button" mat-stroked-button aria-label="Insert"
@@ -18,7 +19,6 @@
       </ng-container>
 
       <ng-template #showButtonsWithoutText>
-
         <!-- button new-->
         <button *ngIf="insertButton && !insertButtonFloatable" type="button" class="o-grid-add-button" mat-icon-button aria-label="Insert"
           (click)="add()">
@@ -56,14 +56,19 @@
         </mat-form-field>
       </div>
 
-      <div fxLayoutAlign="center center" fxFlex>
-        <span *ngIf="hasTitle()" fxLayoutAlign="center center">{{ title | oTranslate }}</span>
-      </div>
+    </ng-container>
+    <ng-content select="[o-grid-toolbar][position=start]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-content select="[o-grid-toolbar][position=end]" ngProjectAs="[o-data-toolbar-custom-projection-end]">
+    </ng-content>
+    <ng-content select="[o-grid-toolbar]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-container o-data-toolbar-projection-end>
       <o-search-input *ngIf="quickFilter" [columns]="quickFilterColumns" [filter-case-sensitive]="filterCaseSensitive"
         [show-case-sensitive-checkbox]="showCaseSensitiveCheckbox()" [placeholder]="quickFilterPlaceholder" [appearance]="quickFilterAppearance"
         float-label="never"></o-search-input>
-    </div>
-  </mat-toolbar>
+    </ng-container>
+  </o-data-toolbar>
 
   <!--no results-->
   <div class="o-grid-no-results fill-remaining" *ngIf="gridItems.length === 0" fxLayoutAlign="center start" layout-padding>

--- a/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.component.scss
@@ -6,17 +6,12 @@
     height: 100%;
     display: flex;
 
-    .o-grid-toolbar {
-      flex: 0 0 auto;
-    }
-
     .o-grid-no-results {
       padding: 16px;
     }
 
     .o-grid-paginator,
     .o-grid-sort {
-      font-size: .8em;
       margin-right: 1em;
     }
 

--- a/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.module.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/grid/o-grid.module.ts
@@ -4,13 +4,14 @@ import { RouterModule } from '@angular/router';
 
 import { OSharedModule } from '../../shared/shared.module';
 import { OSearchInputModule } from '../input/search-input/o-search-input.module';
+import { ODataToolbarModule } from '../o-data-toolbar/o-data-toolbar.module';
 import { OGridItemComponent } from './grid-item/o-grid-item.component';
 import { OGridItemDirective } from './grid-item/o-grid-item.directive';
 import { OGridComponent } from './o-grid.component';
 
 @NgModule({
   declarations: [OGridComponent, OGridItemDirective, OGridItemComponent],
-  imports: [CommonModule, OSearchInputModule, OSharedModule, RouterModule],
+  imports: [CommonModule, OSearchInputModule, OSharedModule, RouterModule, ODataToolbarModule],
   exports: [OGridComponent, OGridItemComponent, OGridItemDirective],
   entryComponents: [OGridItemComponent]
 })

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list-theme.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list-theme.scss
@@ -5,10 +5,6 @@
 
   .o-list-container {
 
-    .mat-toolbar {
-      background: transparent;
-    }
-
     .primary-text {
       color: mat-color($foreground, text);
     }

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.html
@@ -3,9 +3,8 @@
     class="spinner-container">
     <mat-progress-spinner strokeWidth="3" mode="indeterminate"></mat-progress-spinner>
   </div>
-
-  <mat-toolbar *ngIf="hasControls()" [class.dense]="odense" fxFlex="0 1 auto">
-    <div class="mat-toolbar-tools" fxLayout="row" fxFill fxLayoutAlign="start center">
+  <o-data-toolbar *ngIf="hasControls()" [class.dense]="odense" fxFlex="0 1 auto" [title]="title" [show-title]="hasTitle()" class="toolbar">
+    <ng-container o-data-toolbar-projection-start>
       <ng-container *ngIf="showButtonsText;else showButtonsWithoutText">
         <button *ngIf="insertButton && !insertButtonFloatable" type="button" mat-stroked-button aria-label="Insert" (click)="add($event)">
           <mat-icon svgIcon="ontimize:add"></mat-icon>
@@ -37,15 +36,19 @@
           <mat-icon svgIcon="ontimize:delete"></mat-icon>
         </button>
       </ng-template>
-      <div fxLayoutAlign="center center" fxFlex>
-        <span *ngIf="hasTitle()" fxLayoutAlign="center center">{{ title | oTranslate }}</span>
-      </div>
+    </ng-container>
+    <ng-content select="[o-list-toolbar][position=start]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-content select="[o-list-toolbar][position=end]" ngProjectAs="[o-data-toolbar-custom-projection-end]">
+    </ng-content>
+    <ng-content select="[o-list-toolbar]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-container o-data-toolbar-projection-end>
       <o-search-input *ngIf="quickFilter" [filter-case-sensitive]="filterCaseSensitive" [show-case-sensitive-checkbox]="showCaseSensitiveCheckbox()"
         [columns]="quickFilterColumns" [placeholder]="quickFilterPlaceholder" [appearance]="quickFilterAppearance" float-label="never">
       </o-search-input>
-    </div>
-  </mat-toolbar>
-
+    </ng-container>
+  </o-data-toolbar>
   <div fxLayout="column" class="o-list-content" fxFlex="1 1 100%" [class.o-list-content-toolbar-dense]="hasControls() && odense">
 
     <!--MAT-LIST-->

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.html
@@ -3,7 +3,7 @@
     class="spinner-container">
     <mat-progress-spinner strokeWidth="3" mode="indeterminate"></mat-progress-spinner>
   </div>
-  <o-data-toolbar *ngIf="hasControls()" [class.dense]="odense" fxFlex="0 1 auto" [title]="title" [show-title]="hasTitle()" class="toolbar">
+  <o-data-toolbar *ngIf="hasControls()" [class.dense]="odense" [title]="title" [show-title]="hasTitle()" class="o-list-toolbar">
     <ng-container o-data-toolbar-projection-start>
       <ng-container *ngIf="showButtonsText;else showButtonsWithoutText">
         <button *ngIf="insertButton && !insertButtonFloatable" type="button" mat-stroked-button aria-label="Insert" (click)="add($event)">

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.component.scss
@@ -25,14 +25,6 @@
   position: relative;
   flex-direction: column;
 
-  .mat-toolbar {
-    padding: 0 4px;
-
-    &.dense {
-      height: 48px;
-    }
-  }
-
   .o-list-content {
     &.o-list-content-toolbar-dense {
       .add-button {
@@ -41,10 +33,6 @@
         }
       }
     }
-  }
-
-  .o-list-title {
-    font-size: 1.5em;
   }
 
   .spinner-container {

--- a/projects/ontimize-web-ngx/src/lib/components/list/o-list.module.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/list/o-list.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 
 import { OSharedModule } from '../../shared/shared.module';
 import { OSearchInputModule } from '../input/search-input/o-search-input.module';
+import { ODataToolbarModule } from '../o-data-toolbar/o-data-toolbar.module';
 import { OListItemComponent } from './list-item/o-list-item.component';
 import { OListComponent } from './o-list.component';
 import { OListItemAvatarComponent } from './renderers/avatar/o-list-item-avatar.component';
@@ -21,7 +22,7 @@ import { OListItemTextComponent } from './renderers/text/o-list-item-text.compon
     OListItemCardComponent,
     OListItemTextComponent
   ],
-  imports: [CommonModule, OSearchInputModule, OSharedModule, RouterModule],
+  imports: [CommonModule, OSearchInputModule, OSharedModule, RouterModule, ODataToolbarModule],
   exports: [
     OListComponent,
     OListItemComponent,

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.html
@@ -1,9 +1,7 @@
-<div fxLayout="row" fxLayoutAlign="space-between center">
-  <ng-content select="[o-data-toolbar-projection-start]"></ng-content>
-  <ng-content select="[o-data-toolbar-custom-projection-start]"></ng-content>
-  <div fxFlex>
-    <span fxLayoutAlign="center center" *ngIf="showTitle">{{ title | oTranslate }}</span>
-  </div>
-  <ng-content select="[o-data-toolbar-custom-projection-end]"></ng-content>
-  <ng-content select="[o-data-toolbar-projection-end]"></ng-content>
+<ng-content select="[o-data-toolbar-projection-start]"></ng-content>
+<ng-content select="[o-data-toolbar-custom-projection-start]"></ng-content>
+<div fxFlex>
+  <span fxLayoutAlign="center center" *ngIf="showTitle" class="title">{{ title | oTranslate }}</span>
 </div>
+<ng-content select="[o-data-toolbar-custom-projection-end]"></ng-content>
+<ng-content select="[o-data-toolbar-projection-end]"></ng-content>

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.html
@@ -1,0 +1,9 @@
+<div fxLayout="row" fxLayoutAlign="space-between center">
+  <ng-content select="[o-data-toolbar-projection-start]"></ng-content>
+  <ng-content select="[o-data-toolbar-custom-projection-start]"></ng-content>
+  <div fxFlex>
+    <span fxLayoutAlign="center center" *ngIf="showTitle">{{ title | oTranslate }}</span>
+  </div>
+  <ng-content select="[o-data-toolbar-custom-projection-end]"></ng-content>
+  <ng-content select="[o-data-toolbar-projection-end]"></ng-content>
+</div>

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.scss
@@ -1,0 +1,20 @@
+.o-data-toolbar {
+  padding: 0 4px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  align-content: space-between;
+  width: 100%;
+  flex-direction: row;
+  white-space: nowrap;
+
+  &.dense {
+    height: 48px;
+  }
+
+  .title {
+    font-size: 18px;
+    font-weight: 400;
+    text-align: center;
+  }
+}

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { InputConverter } from '../../decorators/input-converter';
+
+
+export const DEFAULT_INPUTS_O_DATA_TOOLBAR = [
+  // show-title [yes|no|true|false]: show the table title. Default: no.
+  'showTitle: show-title',
+  //title: This title value will appear in the toolbar
+  'title',
+
+];
+
+@Component({
+  selector: 'o-data-toolbar',
+  templateUrl:'./o-data-toolbar.component.html',
+  inputs: DEFAULT_INPUTS_O_DATA_TOOLBAR,
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class ODataToolbarComponent {
+  @InputConverter()
+  showTitle: boolean = false;
+
+  public title: string;
+
+  constructor() { }
+
+
+
+}

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ViewEncapsulation } from '@angular/core';
 import { InputConverter } from '../../decorators/input-converter';
 
 
@@ -12,18 +12,19 @@ export const DEFAULT_INPUTS_O_DATA_TOOLBAR = [
 
 @Component({
   selector: 'o-data-toolbar',
-  templateUrl:'./o-data-toolbar.component.html',
+  templateUrl: './o-data-toolbar.component.html',
+  styleUrls: ['./o-data-toolbar.component.scss'],
   inputs: DEFAULT_INPUTS_O_DATA_TOOLBAR,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host:
+    { class: 'o-data-toolbar' }
+
 })
 export class ODataToolbarComponent {
   @InputConverter()
   showTitle: boolean = false;
 
   public title: string;
-
-  constructor() { }
-
-
 
 }

--- a/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.module.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/o-data-toolbar/o-data-toolbar.module.ts
@@ -1,0 +1,16 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { OSharedModule } from '../../shared/shared.module';
+import { ODataToolbarComponent } from './o-data-toolbar.component';
+
+@NgModule({
+  declarations: [
+    ODataToolbarComponent
+  ],
+  imports: [CommonModule, OSharedModule, RouterModule],
+  exports: [
+    ODataToolbarComponent
+  ]
+})
+export class ODataToolbarModule { }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -1,17 +1,19 @@
 <div class="o-table-container" fxLayout="column" fxLayoutAlign="start stretch" [style.display]="isVisible()? '' : 'none'"
   [class.block-events]="showLoading | async">
-  <div #tableToolbar *ngIf="hasControls()" class="toolbar">
-    <div fxLayout="row" fxLayoutAlign="space-between center">
+
+  <o-data-toolbar #tableToolbar *ngIf="hasControls()" [title]="title" [show-title]="showTitle" class="toolbar">
+    <ng-container o-data-toolbar-projection-start>
       <o-table-buttons #tableButtons [insert-button]="insertButton" [refresh-button]="refreshButton" [delete-button]="showDeleteButton">
         <ng-content select="o-table-button"></ng-content>
       </o-table-buttons>
-
-      <ng-content select="[o-table-custom-toolbar]"></ng-content>
-
-      <div fxLayout fxFlex>
-        <span *ngIf="showTitle" class="table-title" fxFlex>{{ title | oTranslate }}</span>
-      </div>
-
+    </ng-container>
+    <ng-content select="[o-table-toolbar][position=start]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-content select="[o-table-toolbar][position=end]" ngProjectAs="[o-data-toolbar-custom-projection-end]">
+    </ng-content>
+    <ng-content select="[o-table-toolbar]" ngProjectAs="[o-data-toolbar-custom-projection-start]">
+    </ng-content>
+    <ng-container o-data-toolbar-projection-end>
       <ng-container *ngIf="quickfilterContentChild; else defaultQuickFilter">
         <ng-content select="o-table-quickfilter"></ng-content>
       </ng-container>
@@ -21,8 +23,6 @@
           </o-table-quickfilter>
         </ng-container>
       </ng-template>
-
-
       <button type="button" *ngIf="showTableMenuButton" mat-icon-button class="o-table-menu-button" [matMenuTriggerFor]="tableMenu.matMenu"
         (click)="$event.stopPropagation()">
         <mat-icon svgIcon="ontimize:more_vert"></mat-icon>
@@ -36,9 +36,11 @@
       <ng-template #exportOptsTemplate>
         <ng-content select="o-table-export-button"></ng-content>
       </ng-template>
-    </div>
-  </div>
+    </ng-container>
 
+    <!-- <ng-container select="o-table-custom-toolbar[position=end], o-grid-custom-toolbar[position=end], o-grid-custom-toolbar[position=end]"></ng-container> -->
+
+  </o-data-toolbar>
 
   <div #tableBody class="o-table-body o-scroll" [class.horizontal-scroll]="horizontalScroll" [class.scrolled]="horizontalScrolled">
     <ng-container *ngIf="!enabledVirtualScroll; else tableWithVirtualScroll">

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.html
@@ -1,7 +1,7 @@
 <div class="o-table-container" fxLayout="column" fxLayoutAlign="start stretch" [style.display]="isVisible()? '' : 'none'"
   [class.block-events]="showLoading | async">
 
-  <o-data-toolbar #tableToolbar *ngIf="hasControls()" [title]="title" [show-title]="showTitle" class="toolbar">
+  <o-data-toolbar #tableToolbar *ngIf="hasControls()" [title]="title" [show-title]="showTitle" class="o-table-toolbar">
     <ng-container o-data-toolbar-projection-start>
       <o-table-buttons #tableButtons [insert-button]="insertButton" [refresh-button]="refreshButton" [delete-button]="showDeleteButton">
         <ng-content select="o-table-button"></ng-content>
@@ -37,9 +37,6 @@
         <ng-content select="o-table-export-button"></ng-content>
       </ng-template>
     </ng-container>
-
-    <!-- <ng-container select="o-table-custom-toolbar[position=end], o-grid-custom-toolbar[position=end], o-grid-custom-toolbar[position=end]"></ng-container> -->
-
   </o-data-toolbar>
 
   <div #tableBody class="o-table-body o-scroll" [class.horizontal-scroll]="horizontalScroll" [class.scrolled]="horizontalScrolled">

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -70,20 +70,10 @@ $o_table_row_padding: 24px;
         margin: 0 10px 0 4px;
       }
 
-      .table-title {
-        font-size: 18px;
-        font-weight: 400;
-        text-align: center;
-      }
+
     }
 
     .o-table-body {
-      .table-title {
-        font-size: 18px;
-        font-weight: 400;
-        text-align: center;
-      }
-      // display: block;
       max-width: 100%;
       height: 100%;
       overflow: hidden;

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -50,8 +50,8 @@ $o_table_row_padding: 24px;
     &.block-events {
       pointer-events: none;
 
-       > .o-table-body .mat-header-row,
-      > .o-table-toolbar {
+       > .o-table-toolbar,
+      > .o-table-body .mat-header-row {
         opacity: .75;
       }
     }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -50,8 +50,8 @@ $o_table_row_padding: 24px;
     &.block-events {
       pointer-events: none;
 
-       > .toolbar,
-      > .o-table-body .mat-header-row {
+       > .o-table-body .mat-header-row,
+      > .o-table-toolbar {
         opacity: .75;
       }
     }
@@ -59,7 +59,7 @@ $o_table_row_padding: 24px;
     position: relative;
     padding: 0 .5%;
 
-    .toolbar {
+    .o-table-toolbar {
       height: 40px;
 
       > div {
@@ -69,7 +69,6 @@ $o_table_row_padding: 24px;
       .buttons {
         margin: 0 10px 0 4px;
       }
-
 
     }
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.module.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.module.ts
@@ -30,6 +30,7 @@ import { PortalModule } from '@angular/cdk/portal';
 import { ODualListSelectorModule } from '../dual-list-selector/o-dual-list-selector.module';
 import { HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { OTableGestureConfig } from './config/o-table-gesture-config';
+import { ODataToolbarModule } from '../o-data-toolbar/o-data-toolbar.module';
 
 @NgModule({
   declarations: [
@@ -58,7 +59,8 @@ import { OTableGestureConfig } from './config/o-table-gesture-config';
     ObserversModule,
     OMatSortModule,
     NgxMaterialTimepickerModule,
-    ODualListSelectorModule
+    ODualListSelectorModule,
+    ODataToolbarModule
   ],
   exports: [
     OTableComponent,

--- a/projects/ontimize-web-ngx/src/lib/components/theming/app-global-theme.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/theming/app-global-theme.scss
@@ -170,7 +170,7 @@
   /*BUTTONS HOVER*/
   .mat-dialog-actions,
   .o-form .o-form-toolbar,
-  .ontimize-table.o-table .o-table-container .toolbar .buttons {
+  .ontimize-table.o-table .o-table-container .o-table-toolbar .buttons {
     .o-table-button,
     button {
       margin: 0 8px;
@@ -265,7 +265,7 @@
   }
 
   .o-form .o-form-toolbar button,
-  .ontimize-table.o-table .o-table-container .toolbar .buttons .o-table-button button {
+  .ontimize-table.o-table .o-table-container .o-table-toolbar .buttons .o-table-button button {
     &.mat-stroked-button {
       padding: 0 6px;
 


### PR DESCRIPTION
- New component o-data-toolbar
-  New CSS class `o-table-toolbar`, `o-list-toolbar`, `o-grid-toolbar`
-  Unified the styles of the titles of the `o-table`, `o-list`, `o-grid` with new CSS class to `title` and therefore removed CSS class `table-title` and `o-list-title`