### PR TITLE
Reverting the removal of the SQLOrder type export

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/types/index.ts
+++ b/projects/ontimize-web-ngx/src/lib/types/index.ts
@@ -34,4 +34,5 @@ export * from './quick-filter-function.type';
 export * from './remote-configuration.type';
 export * from './service-request-param.type';
 export * from './session-info.type';
+export * from './sql-order.type';
 export * from './o-grouped-column-types.type'


### PR DESCRIPTION
Reverting the removal of the SQLOrder type export