### PR TITLE
o-table with pageable=no the filter by column does not work

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/input/input.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/input/input.scss
@@ -70,6 +70,7 @@ $width24: 24px;
         .mat-icon {
           height: $suffix-size;
           line-height: $suffix-size;
+          width: $suffix-size;
         }
 
         .mat-icon-button {

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/default-o-table.datasource.ts
@@ -123,9 +123,7 @@ export class DefaultOTableDataSource extends DataSource<any> implements OTableDa
       displayDataChanges.push(this._virtualPageChange);
     }
 
-    if (this.table.oTableColumnsFilterComponent) {
-      displayDataChanges.push(this._columnValueFilterChange);
-    }
+    displayDataChanges.push(this._columnValueFilterChange);
 
     if (this.table.groupable) {
       displayDataChanges.push(this.groupByColumnChange);

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -2596,7 +2596,8 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
       this.isColumnFiltersActive = confFilterColumnActiveByDefault || this.state.columnValueFilters.length > 0;
     }
 
-    if (this.oTableColumnsFilterComponent) {
+    if (Util.isDefined(storage.columnValueFilters)) {
+      this.state.initialConfiguration
       this.dataSource.initializeColumnsFilters(this.state.columnValueFilters);
       this.onFilterByColumnChange.emit();
     }

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -2226,7 +2226,9 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   filterByColumn(columnValueFilter: OColumnValueFilter) {
     this.dataSource.addColumnFilter(columnValueFilter);
     this.onFilterByColumnChange.emit();
-    this.reloadPaginatedDataFromStart(false);
+    if (this.pageable) {
+      this.reloadPaginatedDataFromStart(false);
+    }
   }
 
   clearColumnFilters(triggerDatasourceUpdate: boolean = true, columnsAttr?: string[]): void {

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -2597,7 +2597,6 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     }
 
     if (Util.isDefined(storage.columnValueFilters)) {
-      this.state.initialConfiguration
       this.dataSource.initializeColumnsFilters(this.state.columnValueFilters);
       this.onFilterByColumnChange.emit();
     }

--- a/projects/ontimize-web-ngx/src/lib/services/state/o-table-component-state.service.ts
+++ b/projects/ontimize-web-ngx/src/lib/services/state/o-table-component-state.service.ts
@@ -106,9 +106,7 @@ export class OTableComponentStateService extends AbstractComponentStateService<O
         result = this.getInitialConfigurationState();
         break;
       case 'filter-column-active':
-        if (this.component.oTableColumnsFilterComponent) {
           result['filter-column-active'] = this.component.isColumnFiltersActive;
-        }
         break;
       case 'filter-columns':
         result['filter-columns'] = this.component.filterColumns;
@@ -180,7 +178,7 @@ export class OTableComponentStateService extends AbstractComponentStateService<O
 
   protected getColumnFiltersState() {
     const result = {};
-    if (this.component.oTableColumnsFilterComponent && this.component.dataSource) {
+    if (this.component.dataSource) {
       const columnValueFilters = this.component.dataSource.getColumnValueFilters();
       if (columnValueFilters.length > 0) {
         result['column-value-filters'] = columnValueFilters;


### PR DESCRIPTION
Fixed  
- not filtering when there is no OTableColumnsFilterComponet configured
- column filter values ​​being saved to localstorate
- scrolling being shown when filtering by column in custom mode with `appearance = padding`