### PR TITLE
[8.x.x] Translate o-button-toggle-group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 8.8.1
+***o-button-toggle**: Fixed `o-button-toggle` labels inside `o-button-toggle-group` not being translated ([13c131e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/13c131e)) Closes[#1073](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1073)
+
 ## 8.8.0 (2022-10-25)
 ### Features:
 * **o-table**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 8.8.1
-***o-button-toggle**: Fixed `o-button-toggle` labels inside `o-button-toggle-group` not being translated ([13c131e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/13c131e)) Closes[#1073](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1073)
+* **o-button-toggle**: Fixed `o-button-toggle` labels inside `o-button-toggle-group` not being translated ([13c131e](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/13c131e)) Closes [#1073](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1073)
 
 ## 8.8.0 (2022-10-25)
 ### Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ontimize-web-ngx",
-  "version": "8.8.1-SNAPSHOT-0",
+  "version": "8.8.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ontimize-web-ngx/package.json
+++ b/projects/ontimize-web-ngx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontimize-web-ngx",
   "homepage": "https://github.com/OntimizeWeb/ontimize-web-ngx#readme",
-  "version": "8.8.1-SNAPSHOT-0",
+  "version": "8.8.1",
   "description": "Ontimize Web framework using Angular 8",
   "bugs": "https://github.com/OntimizeWeb/ontimize-web-ngx/issues",
   "author": "Imatia S.L.",

--- a/projects/ontimize-web-ngx/package.json
+++ b/projects/ontimize-web-ngx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ontimize-web-ngx",
   "homepage": "https://github.com/OntimizeWeb/ontimize-web-ngx#readme",
-  "version": "8.8.0",
+  "version": "8.8.1-SNAPSHOT-0",
   "description": "Ontimize Web framework using Angular 8",
   "bugs": "https://github.com/OntimizeWeb/ontimize-web-ngx/issues",
   "author": "Imatia S.L.",

--- a/projects/ontimize-web-ngx/src/lib/components/button-toggle/o-button-toggle.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/button-toggle/o-button-toggle.component.html
@@ -1,5 +1,5 @@
 <mat-button-toggle #bt [id]="oattr" [name]="name" [checked]="checked" [disabled]="!enabled" [value]="value" (change)="onChange.emit($event)">
   <mat-icon *ngIf="icon && iconPosition==='before'">{{ icon }}</mat-icon>
-  {{ label }}
+  {{ label | oTranslate }}
   <mat-icon *ngIf="icon && iconPosition==='after'">{{ icon }}</mat-icon>
 </mat-button-toggle>


### PR DESCRIPTION
Fixed `o-button-toggle` labels inside `o-button-toggle-group` not being translated