### PR TITLE
Form-layout-manager with mode='tab' sometimes does not open detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 8.8.4
+## 8.8.4 (2022-12-21)
+### Bug fixes
+* **o-form-layout-tabgroup**: Fixed not opening the detail tab if you had previously opened a new tab again ([0e75eb8](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/0e75eb8)) Closes [#1115](https://github.com/OntimizeWeb/ontimize-web-ngx/issues/1115)
+
 ## 8.8.3 (2022-12-19)
 * **o-phone-input**:
   * Add new input `gap` ([9d8e602](https://github.com/OntimizeWeb/ontimize-web-ngx/commit/9d8e602))

--- a/projects/ontimize-web-ngx/src/lib/layouts/form-layout/tabgroup/o-form-layout-tabgroup.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/layouts/form-layout/tabgroup/o-form-layout-tabgroup.component.ts
@@ -181,7 +181,10 @@ export class OFormLayoutTabGroupComponent implements OFormLayoutManagerMode, Aft
     if (addNewComp) {
       this.data.forEach(comp => {
         const currParams = comp.params || {};
-        const someDiffParams =  Object.keys(currParams).some(key => currParams[key] != newCompParams[key]);
+        let someDiffParams = true;
+        if (Object.keys(currParams).length > 0) {
+          someDiffParams = Object.keys(currParams).some(key => currParams[key] != newCompParams[key]);
+        }
         addNewComp = addNewComp && someDiffParams;
       });
     }


### PR DESCRIPTION
Fixed not opening the detail tab if you had previously opened a new tab again