### PR TITLE
Set auto-align-titles=true by default

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/column/cell-renderer/service/o-table-cell-renderer-service.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/column/cell-renderer/service/o-table-cell-renderer-service.component.ts
@@ -105,7 +105,7 @@ export class OTableCellRendererServiceComponent extends OBaseTableCellRenderer i
     super.initialize();
     if (this.table) {
       const oCol: OColumn = this.table.getOColumn(this.column);
-      oCol.definition.contentAlign = oCol.definition.contentAlign ? oCol.definition.contentAlign : 'center';
+      oCol.definition.contentAlign = oCol.definition.contentAlign ? oCol.definition.contentAlign : 'start';
     }
 
     this.colArray = Util.parseArray(this.columns, true);

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.scss
@@ -6,11 +6,10 @@
   display: inline-block;
   width: 13px;
   position: absolute;
-  right: 0;
   top: 6px;
   bottom: 6px;
-
   right:-6px;
+
   span {
     height: 100%;
     width: 1px;

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-column-resizer/o-table-column-resizer.component.scss
@@ -2,6 +2,7 @@
   &:not(.disabled) {
     cursor: col-resize;
   }
+
   display: inline-block;
   width: 13px;
   position: absolute;
@@ -9,6 +10,7 @@
   top: 6px;
   bottom: 6px;
 
+  right:-6px;
   span {
     height: 100%;
     width: 1px;

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header-column-filter-icon/o-table-header-column-filter-icon.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header-column-filter-icon/o-table-header-column-filter-icon.component.scss
@@ -1,12 +1,24 @@
 .o-table .o-table-container .mat-table .mat-header-cell {
+
+  &:has(.o-table-column-filter-icon) {
+    padding-left: 6px;
+  }
+
+  &:has(.mat-sort-header-arrow) {
+    padding-right: 6px;
+  }
+
   .o-table-column-filter-icon {
+    position: relative;
     display: flex;
-    position: absolute;
-    left: 0;
+
+    .mat-icon {
+      align-self: center;
+    }
 
     .o-table-header-indicator-numbered {
       right: -5px;
-      bottom: -8px;
+      bottom: -6px
     }
   }
 }

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.html
@@ -2,10 +2,10 @@
 </o-table-header-column-filter-icon>
 
 <ng-container *ngIf="column.orderable">
-    <span o-mat-sort-header>{{ column.title | oTranslate }}</span>
+  <span o-mat-sort-header fxFlex>{{ column.title | oTranslate }}</span>
 </ng-container>
 <ng-container *ngIf="!column.orderable">
-    <span class="header-title-container">{{ column.title | oTranslate }}</span>
+  <span class="header-title-container" fxFlex>{{ column.title | oTranslate }}</span>
 </ng-container>
 
 <o-table-column-resizer *ngIf="resizable" [column]="column"></o-table-column-resizer>

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.scss
@@ -1,0 +1,14 @@
+.o-table-header {
+  display: flex;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  // align-items: center;
+
+  span[o-mat-sort-header] {
+    flex: 1;
+    min-width: 0;
+  }
+
+}

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-header/o-table-header.component.ts
@@ -11,6 +11,7 @@ export const DEFAULT_INPUTS_O_TABLE_HEADER = [
   selector: 'o-table-header',
   inputs: DEFAULT_INPUTS_O_TABLE_HEADER,
   templateUrl: './o-table-header.component.html',
+  styleUrls:['./o-table-header.component.scss'],
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {

--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/sort/sort-header.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/sort/sort-header.scss
@@ -8,6 +8,7 @@ $mat-sort-header-arrow-hint-opacity: .38;
 .mat-sort-header-container {
   display: flex;
   cursor: pointer;
+  align-items: center;
 
   .mat-sort-header-disabled & {
     cursor: default;
@@ -17,6 +18,7 @@ $mat-sort-header-arrow-hint-opacity: .38;
 .mat-sort-header-position-before {
   flex-direction: row-reverse;
 }
+
 
 .mat-sort-header-button {
   border: none;
@@ -28,13 +30,17 @@ $mat-sort-header-arrow-hint-opacity: .38;
   outline: 0;
   font: inherit;
   color: currentColor;
+
+  &:has(.mat-sort-header-arrow) {
+    padding-right: 6px;
+  }
 }
 
 .mat-sort-header-arrow {
   height: $mat-sort-header-arrow-container-size;
   width: $mat-sort-header-arrow-container-size;
   min-width: $mat-sort-header-arrow-container-size;
-  margin: 0 0 0 $mat-sort-header-arrow-margin;
+  margin: 0 $mat-sort-header-arrow-margin 0 0;
   position: relative;
   display: flex;
 

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.scss
@@ -127,14 +127,6 @@ $o_table_row_padding: 24px;
       }
 
       &.small {
-        .column-filter-icon {
-          margin-top: 2px;
-        }
-
-        .mat-sort-header-arrow {
-          margin-top: 4px;
-        }
-
         .mat-header-row,
         .mat-row {
           .mat-checkbox-inner-container {
@@ -161,14 +153,6 @@ $o_table_row_padding: 24px;
       }
 
       &.medium {
-        .column-filter-icon {
-          margin-top: 2px;
-        }
-
-        .mat-sort-header-arrow {
-          margin-top: 5px;
-        }
-
         .mat-header-row,
         .mat-row {
           .mat-checkbox-inner-container {
@@ -184,17 +168,6 @@ $o_table_row_padding: 24px;
             }
           }
         }
-      }
-
-      &.large {
-        .column-filter-icon {
-          margin-top: 4px;
-        }
-
-        .mat-sort-header-arrow {
-          margin-top: 7px;
-        }
-
       }
 
       tr.mat-row.o-table-row-expanded {
@@ -222,6 +195,7 @@ $o_table_row_padding: 24px;
         /* Non-prefixed version, currently supported by Chrome and Opera */
         user-select: none;
 
+        .mat-header-cell,
         .mat-cell {
           padding: 0 12px;
           overflow: hidden;
@@ -332,10 +306,6 @@ $o_table_row_padding: 24px;
         padding: 0 12px;
         vertical-align: middle;
 
-        &.resizable {
-          padding-right: 24px;
-        }
-
         &.mat-column-select.mat-header-select-all-with-title {
           padding-right: 12px;
         }
@@ -368,11 +338,9 @@ $o_table_row_padding: 24px;
 
         .column-filter-icon {
           cursor: pointer;
-          float: left;
           font-size: 18px;
           width: 18px;
           height: 18px;
-          margin-right: 2px;
           line-height: 1;
         }
 
@@ -382,17 +350,9 @@ $o_table_row_padding: 24px;
           place-content: center;
         }
 
-        .mat-sort-header-arrow {
-          position: absolute;
-          right: 0;
-        }
-
         .header-title-container {
           cursor: default;
-        }
-
-        &.resizable .mat-sort-header-arrow {
-          margin-right: 12px;
+          min-height: 20px;
         }
 
         .header-title-container,
@@ -410,14 +370,6 @@ $o_table_row_padding: 24px;
         &.center,
         &.center .mat-sort-header-button {
           text-align: center;
-        }
-
-        &.center {
-          [o-mat-sort-header] {
-            .mat-sort-header-button {
-              padding-left: 12px;
-            }
-          }
         }
 
         &.end,

--- a/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
+++ b/projects/ontimize-web-ngx/src/lib/components/table/o-table.component.ts
@@ -429,7 +429,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
   @InputConverter()
   showPaginatorFirstLastButtons: boolean = true;
   @InputConverter()
-  autoAlignTitles: boolean = false;
+  autoAlignTitles: boolean = true;
   @InputConverter()
   multipleSort: boolean = true;
   @InputConverter()
@@ -701,6 +701,7 @@ export class OTableComponent extends AbstractOServiceComponent<OTableComponentSt
     try {
       this.oTableGlobalConfig = this.injector.get(O_TABLE_GLOBAL_CONFIG);
       this.autoAdjust = this.oTableGlobalConfig.autoAdjust;
+      this.autoAlignTitles = this.oTableGlobalConfig.autoAlignTitles
     } catch (error) {
       // Do nothing because is optional
     }

--- a/projects/ontimize-web-ngx/src/lib/types/table/o-table-global-config.type.ts
+++ b/projects/ontimize-web-ngx/src/lib/types/table/o-table-global-config.type.ts
@@ -1,3 +1,4 @@
 export type OTableGlobalConfig = {
   autoAdjust: boolean;
+  autoAlignTitles: boolean;
 };


### PR DESCRIPTION
- Set `auto-align-titles=true` by default in table headers
- New property `autoAlignTitles` in injection token `O_TABLE_GLOBAL_CONFIG`
- Removed containers with `position:absolute` in the table headers and the adapted styles 
- Fixed title header align and cell align by default in o-table-column are distinct