### PR TITLE
[8.x.x]o-table-quickfilter:Fixes menu open when ENTER in editable column

### DIFF
--- a/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-quickfilter/o-table-quickfilter.component.html
+++ b/projects/ontimize-web-ngx/src/lib/components/table/extensions/header/table-quickfilter/o-table-quickfilter.component.html
@@ -5,7 +5,7 @@
     <mat-placeholder class="placeholder">{{ placeholder | oTranslate}}</mat-placeholder>
     <div matPrefix>
       <mat-icon svgIcon="ontimize:search" [matBadge]="areAllColumnsChecked()?'':getCountColumnsChecked()" matBadgeSize="small"></mat-icon>
-      <button mat-icon-button [matMenuTriggerFor]="menu" (menuClosed)="onMenuClosed()" (click)="$event.stopPropagation()">
+      <button type="button" mat-icon-button [matMenuTriggerFor]="menu" (menuClosed)="onMenuClosed()" (click)="$event.stopPropagation()">
         <mat-icon class="search-icon">expand_more</mat-icon>
       </button>
     </div>


### PR DESCRIPTION
Fixes #1385